### PR TITLE
Clarify "Status" section

### DIFF
--- a/0.1/index.bs
+++ b/0.1/index.bs
@@ -2,7 +2,7 @@
 Title: Next-generation file formats (NGFF)
 Shortname: ome-ngff
 Level: 1
-Status: w3c/ED
+Status: w3c/CG-FINAL
 Group: ome
 URL: https://ngff.openmicroscopy.org/0.1/
 Repository: https://github.com/ome/ngff
@@ -16,8 +16,8 @@ Editor: Josh Moore, Open Microscopy Environment (OME) https://www.openmicroscopy
 Abstract: This document contains next-generation file format (NGFF)
 Abstract: specifications for storing bioimaging data in the cloud.
 Abstract: All specifications are submitted to the https://image.sc community for review.
-Status Text: The current released version of this specification is 0.1. Migration scripts
-Status Text: will be provided between numbered versions. Data written with the latest changes
+Status Text: This is the 0.1 release of this specification. Migration scripts
+Status Text: will be provided between numbered versions. Data written with the latest version
 Status Text: (an "editor's draft") will not necessarily be supported.
 </pre>
 

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -17,8 +17,9 @@ Editor: Josh Moore, Open Microscopy Environment (OME) https://www.openmicroscopy
 Abstract: This document contains next-generation file format (NGFF)
 Abstract: specifications for storing bioimaging data in the cloud.
 Abstract: All specifications are submitted to the https://image.sc community for review.
-Status Text: The current released version of this specification is 0.1. Migration scripts
-Status Text: will be provided between numbered versions. Data written with the latest changes
+Status Text: The current released version of this specification is
+Status Text: <a href="../0.1/index.html">0.1</a>. Migration scripts
+Status Text: will be provided between numbered versions. Data written with these latest changes
 Status Text: (an "editor's draft") will not necessarily be supported.
 </pre>
 


### PR DESCRIPTION
 - Latest now links to 0.1 (could be made clear)
 - 0.1 now says "this version" (requires HTML rather than markdown)
 - Both still explain the upgrade policy (needs more detail)