### PR TITLE
Add link to the ngff site to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ome-ngff
 
-Next-generation file format (NGFF) specifications for storing bioimaging data in the cloud.
+[Next-generation file format (NGFF) specifications](https://ngff.openmicroscopy.org/latest/) for storing bioimaging data in the cloud.
 
 ## Editing
 


### PR DESCRIPTION
This is a tiny thing, but I think it helps to link to the rendered version of the spec more prominently.
(At least for me this is very useful to find it again ;))