### PR TITLE
Lift 5d requirement for images and move multiscales description into spec

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -212,16 +212,16 @@ found under the "multiscales" key in the group-level metadata.
 "multiscales" MUST contain the field "datasets", which is a list of dictionaries describing
 the arrays storing the individual resolution levels. Each dictionary in "datasets" MUST
 contain the field "path", whose value contains the path to the array for this resolution relative
-to the root zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
+to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
+
+It MUST contain the field "axes", which is a list of dimension names of the axes.
+The values MUST be unique and one of `{"t", "c", "z", "y", "x"}`.
+The number of values MUST be the same as the number of dimensions of the arrays corresponding to this image.
 
 It SHOULD contain the field "name".
 
 It SHOULD contain the field "version", which indicates the version of the
-multiscale metadata of this image (current version is 0.1).
-
-It SHOULD contain the field "axes", which is a list of dimension names of the axes.
-If given, the values MUST be unique and one of `{"t", "c", "z", "y", "x"}`.
-The number of values MUST be the same as the number of dimensions of the arrays corresponding to this image.
+multiscale metadata of this image (current version is 0.2).
 
 It SHOULD contain the field "type", which gives the type of downscaling method used to generate the multiscale image pyramid.
 It SHOULD contain the field "metadata", which contains a dictionary with additional information about the downscaling method.
@@ -230,7 +230,7 @@ It SHOULD contain the field "metadata", which contains a dictionary with additio
 {
     "multiscales": [
         {
-            "version": "0.1",
+            "version": "0.2",
             "name": "example",
             "datasets": [
                 {"path": "0"},

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -124,8 +124,8 @@ multiple levels of resolutions and optionally associated labels.
     ├── n                     # The name of the array is arbitrary with the ordering defined by
     │   │                     # by the "multiscales" metadata, but is often a sequence starting at 0.
     │   │
-    │   ├── .zarray           # All image arrays are 5-dimensional
-    │   │                     # with dimension order (t, c, z, y, x).
+    │   ├── .zarray           # All image arrays are up to 5-dimensional with dimension order (t, c, z, y, x).
+    │   │                     # An image without time dimension has axes (c, z, y, x) etc.
     │   │
     │   ├── 0.0.0.0.0         # Chunks are stored with the flat directory layout.
     │   │   ...               # Each dotted component of the chunk file represents

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -207,8 +207,52 @@ keys as specified below for discovering certain types of data, especially images
 
 Metadata about the multiple resolution representations of the image can be
 found under the "multiscales" key in the group-level metadata.
-The specification for the multiscale (i.e. "resolution") metadata is provided
-in [zarr-specs#50](https://github.com/zarr-developers/zarr-specs/issues/50).
+"multiscales" contains a list of dictionaries where each entry describes a multiscale image.
+
+"multiscales" MUST contain the field "datasets", which is a list of dictionaries describing
+the arrays storing the individual resolution levels. Each dictionary in "datasets" MUST
+contain the field "path", whose value contains the path to the array for this resolution relative
+to the root zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
+
+It SHOULD contain the field "name".
+
+It SHOULD contain the field "version", which indicates the version of the
+multiscale metadata of this image (current version is 0.1).
+
+It SHOULD contain the field "axes", which is a list of dimension names of the axes.
+If given, the values MUST be unique and one of `{"t", "c", "z", "y", "x"}`.
+The number of values MUST be the same as the number of dimensions of the arrays corresponding to this image.
+
+It SHOULD contain the field "type", which gives the type of downscaling method used to generate the multiscale image pyramid.
+It SHOULD contain the field "metadata", which contains a dictionary with additional information about the downscaling method.
+
+```json
+{
+    "multiscales": [
+        {
+            "version": "0.1",
+            "name": "example",
+            "datasets": [
+                {"path": "0"},
+                {"path": "1"},
+                {"path": "2"}
+            ],
+            "axes": [
+                "t", "c", "z", "y", "z"
+            ],
+            "type": "gaussian",
+            "metadata": {                                       # the fields in metadata depend on the downscaling implementation
+                "method": "skimage.transform.pyramid_gaussian", # here, the paramters passed to the skimage function are given
+                "version": "0.16.1",
+                "args": "[true]",
+                "kwargs": {"multichannel": true}
+            }
+        }
+    ]
+}
+```
+
+
 If only one multiscale is provided, use it. Otherwise, the user can choose by
 name, using the first multiscale as a fallback:
 

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -209,9 +209,9 @@ Metadata about the multiple resolution representations of the image can be
 found under the "multiscales" key in the group-level metadata.
 "multiscales" contains a list of dictionaries where each entry describes a multiscale image.
 
-"multiscales" MUST contain the field "datasets", which is a list of dictionaries describing
-the arrays storing the individual resolution levels. Each dictionary in "datasets" MUST
-contain the field "path", whose value contains the path to the array for this resolution relative
+Each "multiscales" dictionary MUST contain the field "datasets", which is a list of dictionaries describing
+the arrays storing the individual resolution levels.
+Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative
 to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
 
 It MUST contain the field "axes", which is a list of dimension names of the axes.
@@ -238,7 +238,7 @@ It SHOULD contain the field "metadata", which contains a dictionary with additio
                 {"path": "2"}
             ],
             "axes": [
-                "t", "c", "z", "y", "z"
+                "t", "c", "z", "y", "x"
             ],
             "type": "gaussian",
             "metadata": {                                       # the fields in metadata depend on the downscaling implementation


### PR DESCRIPTION
As discussed in #35 this lifts the restriction for images to be 5-dimensional.

Also, I have added a description of the multiscales metadata based on https://forum.image.sc/t/multiscale-arrays-v0-1/37930.
This will allow us to keep track of changes to the metadata better.

Note that I have added the field "axes" in order to specify the names of axes in the dataset; this becomes necessary due to 
images not having fixed dimension any more. Note that there is still an ongoing discussion about the allowed names for axes (and also about allowing more than 5 dimensions) in #35 and #28. I have not addressed these issues yet, so for now the names are restricted to "t", "c", "x", "y", "z". Also, this is a SHOULD requirement to not break compatibility with 0.1.

@joshmoore 
- I am still refering to the version with 0.1, should it be bumped due to the changes w.r.t. number of dims?
- Do I need to [render the changes locally](https://w3c-ccg.github.io/bikeshed_instructions.html) or is there some CI that also renders PRs? (Would be very convenient :))