### PR TITLE
Finalize axes & initial transformation

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -263,8 +263,9 @@ to the current zarr group. The "path"s MUST be ordered from largest (i.e. highes
 Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
 Each dictionary MAY contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
 The transformations are defined according to [[#trafo-md]]. The transformation types MUST only be `identity`, `translation` or `scale`.
-They MUST contain at most one `scale` transformation per axis that specifies the pixel size in physical units.
-It also MUST contain at most one `translation` per axis that specifies the offset from the origin in physical units.
+They MUST contain at most one `scale` transformation that specifies the pixel size in physical units or time duration.
+It also MUST contain at most one `translation` that specifies the offset from the origin in physical units.
+The length of the `scale` and/or `translation` array MUST be the same as the length of "axes".
 If both `scale` and `translation` are given `translation` must be listed after `scale` to ensure that it is given in physical coordinates. If "coordinateTransformations" is not given, the identity transformation is assumed.
 The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while
 being compatible with the general transformation spec.

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -237,7 +237,7 @@ Additional fields for the entry depend on "type" and are defined by the column `
 | `translation` | one of: `"translation":List[float]`, `"path":str` | translation vector, stored either as a list of floats (`"translation"`) or as binary data at a location in this container (`path`). The length of vector defines number of dimensions. |
 | `scale`       | one of: `"scale":List[float]`, `"path":str` | scale vector, stored either as a list of floats (`scale`) or as binary data at a location in this container (`path`). The length of vector defines number of dimensions. |
 
-The transformations in the list are applied sequentally and in order.
+The transformations in the list are applied sequentially and in order.
 
 
 "multiscales" metadata {#multiscale-md}

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -261,14 +261,12 @@ Each dictionary in "datasets" MUST contain the field "path", whose value contain
 to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
 
 Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
-Each dictionary MAY contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
+Each dictionary MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
 The transformations are defined according to [[#trafo-md]]. The transformation types MUST only be `identity`, `translation` or `scale`.
-They MUST contain at most one `scale` transformation that specifies the pixel size in physical units or time duration.
-It also MUST contain at most one `translation` that specifies the offset from the origin in physical units.
-The length of the `scale` and/or `translation` array MUST be the same as the length of "axes".
-If both `scale` and `translation` are given `translation` must be listed after `scale` to ensure that it is given in physical coordinates. If "coordinateTransformations" is not given, the identity transformation is assumed.
-The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while
-being compatible with the general transformation spec.
+They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes set it to 1.
+It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it must be listed after `scale` to ensure that it is given in physical coordinates.
+The length of the `scale` and `translation` array MUST be the same as the length of "axes".
+The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while being compatible with the general transformation spec.
 
 Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to each resolution level.
 The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations".

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -264,7 +264,7 @@ Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT 
 Each dictionary MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
 The transformations are defined according to [[#trafo-md]]. The transformation MUST only be of type `translation` or `scale`.
 They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes set it to 1.
-It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it must be listed after `scale` to ensure that it is given in physical coordinates.
+It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it MUST be listed after `scale` to ensure that it is given in physical coordinates.
 The length of the `scale` and `translation` array MUST be the same as the length of "axes".
 The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while being compatible with the general transformation spec.
 

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -262,7 +262,7 @@ to the current zarr group. The "path"s MUST be ordered from largest (i.e. highes
 
 Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
 Each dictionary MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
-The transformations are defined according to [[#trafo-md]]. The transformation types MUST only be `translation` or `scale`.
+The transformations are defined according to [[#trafo-md]]. The transformation MUST only be of type `translation` or `scale`.
 They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes set it to 1.
 It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it must be listed after `scale` to ensure that it is given in physical coordinates.
 The length of the `scale` and `translation` array MUST be the same as the length of "axes".

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -222,10 +222,11 @@ keys as specified below for discovering certain types of data, especially images
 If part of [[#multiscale-md]], the length of "axes" MUST be equal to the number of dimensions of the arrays that contain the image data.
 
 
-"transformations" metadata {#trafo-md}
+"coordinateTransformations" metadata {#trafo-md}
 -------------------------------------
 
-"transformations" describes a series of transformations, e.g. to map discrete data space of an array to the corresponding physical space.
+"coordinateTransformations" describe a series of transformations that map between two coordinate spaces (defined by "axes").
+For example, to map a discrete data space of an array to the corresponding physical space.
 It is a list of dictionaries. Each entry describes a single transformation and MUST contain the field "type".
 The value of "type" MUST be one of the elements of the `type` column in the table below.
 Additional fields for the entry depend on "type" and are defined by the column `fields`.
@@ -263,16 +264,16 @@ Each dictionary in "datasets" MUST contain the field "path", whose value contain
 to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
 
 Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
-Each dictionary MAY contain the field "transformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
+Each dictionary MAY contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
 The transformations are defined according to [[#trafo-md]]. In addition, the transformation types MUST only be `identity`, `translation` or `scale`.
 They MUST contain at most one `scale` transformation per axis that specifies the pixel size in physical units.
 It also MUST contain at most one `translation` per axis that specifies the offset from the origin in physical units.
-If both `scale` and `translation` are given `translation` must be listed after `scale` to ensure that it is given in physical coordinates. If "transformations" is not given, the identity transformation is assumed.
+If both `scale` and `translation` are given `translation` must be listed after `scale` to ensure that it is given in physical coordinates. If "coordinateTransformations" is not given, the identity transformation is assumed.
 The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while
 being compatible with the general transformation spec.
 
-Each "multiscales" dictionary MAY contain the field "transformations", describing transformations that are applied to each resolution level.
-The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:transformations".
+Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to each resolution level.
+The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations".
 These transformations are applied after the per resolution level transformations specified in "datasets". They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
 
 Each "multiscales" dictionary SHOULD contain the field "name". It SHOULD contain the field "version", which indicates the version of the multiscale metadata of this image (current version is 0.4).

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -237,9 +237,6 @@ Additional fields for the entry depend on "type" and are defined by the column `
 | `translation` | one of: `"translation":List[float]`, `"path":str` | translation vector, stored either as a list of floats (`"translation"`) or as binary data at a location in this container (`path`). The length of vector defines number of dimensions. |
 | `scale`       | one of: `"scale":List[float]`, `"path":str` | scale vector, stored either as a list of floats (`scale`) or as binary data at a location in this container (`path`). The length of vector defines number of dimensions. |
 
-In addition, the field "axisIndices" MAY be given to specify the subset of axes that the transformation is applied to, leaving other axes unchanged. If not given, the transformation is applied to all axes. The length of "axisIndices" MUST be equal to the dimensionality of the transformation. If "axisIndices" are not given, the dimensionality of the transformation MUST be equal to the number of dimensions of the space that the transformation is applied to.
-If given, "axisIndices" MUST be given in increasing order. It uses zero-based indexing.
-
 The transformations in the list are applied sequentally and in order.
 
 
@@ -265,7 +262,7 @@ to the current zarr group. The "path"s MUST be ordered from largest (i.e. highes
 
 Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
 Each dictionary MAY contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
-The transformations are defined according to [[#trafo-md]]. In addition, the transformation types MUST only be `identity`, `translation` or `scale`.
+The transformations are defined according to [[#trafo-md]]. The transformation types MUST only be `identity`, `translation` or `scale`.
 They MUST contain at most one `scale` transformation per axis that specifies the pixel size in physical units.
 It also MUST contain at most one `translation` per axis that specifies the offset from the origin in physical units.
 If both `scale` and `translation` are given `translation` must be listed after `scale` to ensure that it is given in physical coordinates. If "coordinateTransformations" is not given, the identity transformation is assumed.
@@ -297,18 +294,18 @@ It SHOULD contain the field "metadata", which contains a dictionary with additio
             "datasets": [
                 {
                     "path": "0",
-                    "transformations": [{"type": "scale", "scale": [0.5, 0.5, 0.5], "axisIndices": [2, 3, 4]}]  # the voxel size for the first scale level (0.5 micrometer)
+                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 0.5, 0.5, 0.5]}]  # the voxel size for the first scale level (0.5 micrometer)
                 }
                 {
                     "path": "1",
-                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 1.0], "axisIndices": [2, 3, 4]}]  # the voxel size for the second scale level (downscaled by a factor of 2 -> 1 micrometer)
+                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}]  # the voxel size for the second scale level (downscaled by a factor of 2 -> 1 micrometer)
                 },
                 {
                     "path": "2",
-                    "transformations": [{"type": "scale", "scale": [2.0, 2.0, 2.0], "axisIndices": [2, 3, 4]}]  # the voxel size for the second scale level (downscaled by a factor of 4 -> 2 micrometer)
+                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 2.0, 2.0, 2.0]}]  # the voxel size for the second scale level (downscaled by a factor of 4 -> 2 micrometer)
                 }
             ],
-            "transformations": [{"type": "scale", "scale": [0.1], "axisIndices": [0]],  # the time unit (0.1 milliseconds), which is the same for each scale level
+            "transformations": [{"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0, 1.0]],  # the time unit (0.1 milliseconds), which is the same for each scale level
             "type": "gaussian",
             "metadata": {                                       # the fields in metadata depend on the downscaling implementation
                 "method": "skimage.transform.pyramid_gaussian", # here, the paramters passed to the skimage function are given

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -295,18 +295,18 @@ It SHOULD contain the field "metadata", which contains a dictionary with additio
             "datasets": [
                 {
                     "path": "0",
-                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 0.5, 0.5, 0.5]}]  # the voxel size for the first scale level (0.5 micrometer)
+                    "coordinateTransformations": [{"type": "scale", "scale": [1.0, 1.0, 0.5, 0.5, 0.5]}]  # the voxel size for the first scale level (0.5 micrometer)
                 }
                 {
                     "path": "1",
-                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}]  # the voxel size for the second scale level (downscaled by a factor of 2 -> 1 micrometer)
+                    "coordinateTransformations": [{"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}]  # the voxel size for the second scale level (downscaled by a factor of 2 -> 1 micrometer)
                 },
                 {
                     "path": "2",
-                    "transformations": [{"type": "scale", "scale": [1.0, 1.0, 2.0, 2.0, 2.0]}]  # the voxel size for the second scale level (downscaled by a factor of 4 -> 2 micrometer)
+                    "coordinateTransformations": [{"type": "scale", "scale": [1.0, 1.0, 2.0, 2.0, 2.0]}]  # the voxel size for the second scale level (downscaled by a factor of 4 -> 2 micrometer)
                 }
             ],
-            "transformations": [{"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0, 1.0]],  # the time unit (0.1 milliseconds), which is the same for each scale level
+            "coordinateTransformations": [{"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0, 1.0]],  # the time unit (0.1 milliseconds), which is the same for each scale level
             "type": "gaussian",
             "metadata": {                                       # the fields in metadata depend on the downscaling implementation
                 "method": "skimage.transform.pyramid_gaussian", # here, the paramters passed to the skimage function are given

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -262,15 +262,15 @@ to the current zarr group. The "path"s MUST be ordered from largest (i.e. highes
 
 Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
 Each dictionary MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
-The transformations are defined according to [[#trafo-md]]. The transformation types MUST only be `identity`, `translation` or `scale`.
+The transformations are defined according to [[#trafo-md]]. The transformation types MUST only be `translation` or `scale`.
 They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes set it to 1.
 It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it must be listed after `scale` to ensure that it is given in physical coordinates.
 The length of the `scale` and `translation` array MUST be the same as the length of "axes".
 The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while being compatible with the general transformation spec.
 
-Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to each resolution level.
-The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations".
-These transformations are applied after the per resolution level transformations specified in "datasets". They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
+Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to all resolution levels in the same manner.
+The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations" and are applied after them.
+They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
 
 Each "multiscales" dictionary SHOULD contain the field "name". It SHOULD contain the field "version", which indicates the version of the multiscale metadata of this image (current version is 0.4).
 


### PR DESCRIPTION
Follow up on #57:
- rename `transformations` to `coordinateTransformations`, after discussion in todays meeting with @bogovicj @jbms @lassoan and others
- remove `axisIndices` for simplification. Transformations for a subset of axes will be tackled in future work.

Other points from #57 that should still be addressed:
- order of `scale` and `translation`, raised by @will-moore. We actually restrict this to first `scale`, then `translation`; I will leave a code comment to point this out.
- Give mathematical definition of the current transformation, raised by @jbms

Finally, we may want to remove the transformations applied to all transformations levels; I think that this introduces unnecessary complexity without offering much functionality. (Edit: on second thought we may want to keep it because this will be very useful once we have coordinateTransformations for subsets of axes)

@joshmoore @sbesson @will-moore @bogovicj please review with current implementation in ome-zarr-py / ome-napari, vizarr and the upcoming advanced transformation proposal in mind. Review from everyone else is of course also welcome, but please keep in mind that we don't want to introduce fundamental changes at this point for v0.4; these discussions can happen for the upcoming advanced transformation proposal that will be spearheaded by @bogovicj. 