### PR TITLE
Remove requirement for xarray-compatible metadata

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -264,9 +264,6 @@ The length of "axes" must be between 2 and 5 and MUST be equal to the dimensiona
 The "axes" MUST contain 2 or 3 entries of "type:space" and MAY contain one additional entry of "type:time" and MAY contain one additional entry of "type:channel" or a null / custom type.
 The order of the entries MUST correspond to the order of dimensions of the zarr arrays. In addition, the entries MUST be ordered by "type" where the "time" axis must come first (if present), followed by the  "channel" or custom axis (if present) and the axes of type "space".
 If there are three spatial axes where two correspond to the image plane ("yx") and images are stacked along the other (anisotropic) axis ("z"), the spatial axes SHOULD be ordered as "zyx".
-The values of the "name" fields must be given as a list in the field "_ARRAY_DIMENSIONS" in the attributes (.zattr) of the zarr arrays.
-This ensures compatibility with the [xarray zarr encoding](http://xarray.pydata.org/en/stable/internals/zarr-encoding-spec.html#zarr-encoding).
-E.g. for "axes: [{"name": "z"}, {"name": "y"}, {"name": x}]", the zarr arrays must contain "{"_ARRAY_DIMENSIONS": ["z", "y", "x"]}" in their attributes.
 
 Each "multiscales" dictionary MUST contain the field "datasets", which is a list of dictionaries describing the arrays storing the individual resolution levels.
 Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative


### PR DESCRIPTION
See https://github.com/ome/ngff/issues/48 and https://github.com/ome/ome-zarr-py/issues/166

With the introduction of axes, metadata at the multiscales dataset level allowing compatibility with `xarray` was added in the 0.3 version of the OME-NGFF specification. Some feedback and testing revealed the metadata currently required by the specification generates Zarr group which fail to open in `xarray` due to the different shapes in the resolution `datasets`.

This PR proposes a last-minute amendment to the 0.4 specification which is due for publication imminently to remove the `xarray` metadata. This should prevent libraries from writing datasets known to be not fit-for-purpose at the moment. In the mean time, the discussion can keep going on in https://github.com/ome/ngff/issues/48 about the best way to ensure xarray-compatibility and lead to a formal proposal that can be released in an upcoming versions of the specification.

cc @thewtex 