### PR TITLE
Consume main branch of ome/spec-prod action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ome/spec-prod@v4
+      - uses: ome/spec-prod@main
         with:
           GH_PAGES_BRANCH: gh-pages
           VALIDATE_LINKS: false


### PR DESCRIPTION
This should include the latest changes allowing to publish the JSON schemas under ngff.openmicroscopy.org

See https://github.com/ome/spec-prod/pull/2 for more details