### PR TITLE
Proposal: Add UUID field to multiscale objects

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -295,6 +295,11 @@ Each "multiscales" dictionary:
 
  * SHOULD contain the field "name" which is informative to users but not sufficient for unique identifiation.
 
+ * SHOULD contain the field "uuid" which is a
+   [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) compliant
+   string representation of a universally unique identifier, e.g., "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6" and SHOULD use
+   a compliant generator to minimize potential conflicts.
+
 * SHOULD contain the field "version", which indicates the version of the
   multiscale metadata of this image (current version is [NGFFVERSION]).
 

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -288,14 +288,21 @@ It MAY contain exactly one `translation` that specifies the offset from the orig
 The length of the `scale` and `translation` array MUST be the same as the length of "axes".
 The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while being compatible with the general transformation spec.
 
-Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to all resolution levels in the same manner.
-The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations" and are applied after them.
-They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
+Each "multiscales" dictionary:
+ * MAY contain the field "coordinateTransformations", describing transformations that are applied to all resolution levels in the same manner.
+   The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations" and are applied after them.
+   They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
 
-Each "multiscales" dictionary SHOULD contain the field "name". It SHOULD contain the field "version", which indicates the version of the multiscale metadata of this image (current version is [NGFFVERSION]).
+ * SHOULD contain the field "name" which is informative to users but not sufficient for unique identifiation.
 
-Each "multiscales" dictionary SHOULD contain the field "type", which gives the type of downscaling method used to generate the multiscale image pyramid.
-It SHOULD contain the field "metadata", which contains a dictionary with additional information about the downscaling method.
+* SHOULD contain the field "version", which indicates the version of the
+  multiscale metadata of this image (current version is [NGFFVERSION]).
+
+* SHOULD contain the field "type", which gives the type of downscaling method
+  used to generate the multiscale image pyramid.
+
+* SHOULD contain the field "metadata", which contains a dictionary with
+  additional information about the downscaling method.
 
 <pre class=include-code>
 path: examples/valid_strict/multiscales_example.json


### PR DESCRIPTION
In order to uniquely identify the images that are being generated,
this change proposes that a UUID should be included with each multiscale.
The UUID can either be generated at creation or perhaps copied from
an existing array if all meta(data) is identical (e.g. a rechunking).