### PR TITLE
RF: take the "burden" off @kimdhamilton shoulders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# they will be requested for review when someone opens a 
-# pull request.
-*       @kimdhamilton
-
-# See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax


### PR DESCRIPTION
@kimdhamilton was left while adopting the
https://github.com/w3c-ccg/markdown-to-spec
template for the ngff repository.  I am nobody to the project,
did not know about CODEOWNERS (will consider adding to our own projects)
so was not sure on whom else to add the burden