### PR TITLE
Add Review comment to all PRs.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,5 +22,5 @@ jobs:
           body: |
             #### Automated Review URLs
             * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/ome/ngff/${{github.sha}}/latest/index.bs)
-            * [diff latest modified](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fome%2F%ngff%2F${{github.sha}}%2Flatest%2Findex.bs)
+            * [diff latest modified](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fome%2Fngff%2F${{github.sha}}%2Flatest%2Findex.bs)
           edit-mode: replace

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,12 +15,14 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Automated Review URL
+          body-includes: Automated Review URLs
 
       - uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            * [Automated Review URL](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/${github.repository}}/${{github.ref_name}}/latest/index.bs)
+            #### Automated Review URLs
+            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/${{github.repository}}/${{github.ref_name}}/latest/index.bs)
+            * [diff latest PR](Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2F${{github.repository}}%2F${{github.ref_name}}%2Flatest%2Findex.bs)
           edit-mode: replace

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,7 +2,7 @@
  name: Add review url
 
  on:
-   pull_request:
+   pull_request_target:
 
  jobs:
    build:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -8,8 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
       - uses: peter-evans/find-comment@v2
         id: fc
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,16 @@
+---
+ name: Add review url
+
+ on:
+   pull_request:
+
+ jobs:
+   build:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v2
+       - name: Add comment to PR
+         env:
+           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+         run: |
+           echo no op to enable the workflow

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,16 +1,26 @@
 ---
- name: Add review url
+name: Add review url
 
  on:
    pull_request_target:
 
- jobs:
-   build:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v2
-       - name: Add comment to PR
-         env:
-           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-         run: |
-           echo no op to enable the workflow
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Automated Review URL
+
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            * [Automated Review URL](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/${github.repository}}/${{github.ref_name}}/latest/index.bs)
+          edit-mode: replace

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,8 +1,8 @@
 ---
 name: Add review url
 
- on:
-   pull_request_target:
+on:
+  pull_request_target:
 
 jobs:
   build:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -23,6 +23,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             #### Automated Review URLs
-            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/${{github.repository}}/${{github.ref_name}}/latest/index.bs)
-            * [diff latest PR](Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2F${{github.repository}}%2F${{github.ref_name}}%2Flatest%2Findex.bs)
+            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/ome/ngff/${{github.sha}}/latest/index.bs)
+            * [diff latest modified](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fome%2F%ngff%2F${{github.sha}}%2Flatest%2Findex.bs)
           edit-mode: replace


### PR DESCRIPTION
Replaces #117 since testing workflows from forks is painful.

On each push to a PR, this workflow should add if necessary or otherwise update a comment pointing to the URLs which can be used for reviewing the changes to latest.bs:

![Screen Shot 2022-05-30 at 12 06 29](https://user-images.githubusercontent.com/88113/170969742-b0ceef0e-6fc9-4924-b63b-665a44a7d4c4.png)