### PR TITLE
Add missing ids to strict_image.schemas

### DIFF
--- a/0.1/schemas/strict_image.schema
+++ b/0.1/schemas/strict_image.schema
@@ -1,4 +1,5 @@
 {
+  "$id": "https://ngff.openmicroscopy.org/0.1/schemas/strict_image.schema",
   "allOf": [
     {
       "$ref": "https://ngff.openmicroscopy.org/0.1/schemas/image.schema"

--- a/0.3/schemas/strict_image.schema
+++ b/0.3/schemas/strict_image.schema
@@ -1,4 +1,5 @@
 {
+  "$id": "https://ngff.openmicroscopy.org/0.3/schemas/strict_image.schema",
   "allOf": [
     {
       "$ref": "https://ngff.openmicroscopy.org/0.3/schemas/image.schema"


### PR DESCRIPTION
Validation approach at https://github.com/ome/ome-zarr-py/pull/142/commits/c1ed01653793e318583275dd388e07ecc7419f66 uses the `$id` from each schema to create a local store, but some schemas are missing `$id`.