### PR TITLE
Generalize well organization in high-content screening: field of view => image 

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -184,8 +184,7 @@ The following specification defines the hierarchy for a high-content screening
 dataset. Three groups MUST be defined above the images:
 
 -   the group above the images defines the well and MUST implement the
-    [well specification](#well-md). All images contained in a well are fields
-    of view of the same well
+    [well specification](#well-md). A well is a collection of 1 to m images.
 -   the group above the well defines a row of wells
 -   the group above the well row defines an entire plate i.e. a two-dimensional
     collection of wells organized in rows and columns. It MUST implement the
@@ -208,7 +207,7 @@ A well group SHOULD NOT be present if there are no images in the well.
     │   │   ├── .zgroup
     │   │   ├── .zattrs       # Implements "well" specification
     │   │   │
-    │   │   ├── 0             # First field of view of well A1
+    │   │   ├── 0             # First image of well A1
     │   │   │   │
     │   │   │   ├── .zgroup
     │   │   │   ├── .zattrs   # Implements "multiscales", "omero"
@@ -216,7 +215,7 @@ A well group SHOULD NOT be present if there are no images in the well.
     │   │   │   │   ...       # Resolution levels
     │   │   │   ├── n
     │   │   │   └── labels    # Labels (optional)
-    │   │   ├── ...           # Fields of view
+    │   │   ├── ...           # Images belonging to well A1
     │   │   └── m
     │   ├── ...               # Columns
     │   └── 12
@@ -418,11 +417,11 @@ custom attributes of the plate group under the `plate` key in the group-level me
 The `plate` dictionary MAY contain an `acquisitions` key whose value MUST be a list of
 JSON objects defining the acquisitions for a given plate to which wells can refer to. Each
 acquisition object MUST contain an `id` key whose value MUST be an unique integer identifier
-greater than or equal to 0 within the context of the plate to which fields of view can refer
+greater than or equal to 0 within the context of the plate to which images can refer
 to (see #well-md).
 Each acquisition object SHOULD contain a `name` key whose value MUST be a string identifying
 the name of the acquisition. Each acquisition object SHOULD contain a `maximumfieldcount`
-key whose value MUST be a positive integer indicating the maximum number of fields of view for the
+key whose value MUST be a positive integer indicating the maximum number of images per well for the
 acquisition. Each acquisition object MAY contain a `description` key whose value MUST be a
 string specifying a description for the acquisition. Each acquisition object MAY contain
 a `starttime` and/or `endtime` key whose values MUST be integer epoch timestamps specifying
@@ -438,7 +437,7 @@ other `name` in the `columns` list. Care SHOULD be taken to avoid collisions on
 case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
 
 The `plate` dictionary SHOULD contain a `field_count` key whose value MUST be a positive integer
-defining the maximum number of fields per view across all wells.
+defining the maximum number of images per well across all wells.
 
 The `plate` dictionary SHOULD contain a `name` key whose value MUST be a string defining the
 name of the plate.
@@ -466,7 +465,7 @@ the index into the `columns` list. `rowIndex` and `columnIndex` MUST be 0-based.
 `rowIndex`, `columnIndex`, and `path` MUST all refer to the same row/column pair.
 
 For example the following JSON object defines a plate with two acquisitions and
-6 wells (2 rows and 3 columns), containing up to 2 fields of view per acquisition.
+6 wells (2 rows and 3 columns), containing up to 2 images per acquisition.
 
 <pre class=include-code>
 path: examples/plate_strict/plate_6wells.json
@@ -474,7 +473,7 @@ highlight: json
 </pre>
 
 The following JSON object defines a sparse plate with one acquisition and
-2 wells in a 96 well plate, containing one field of view per acquisition.
+2 wells in a 96 well plate, containing one image per acquisition.
 
 <pre class=include-code>
 path: examples/plate_strict/plate_2wells.json
@@ -484,13 +483,13 @@ highlight: json
 "well" metadata {#well-md}
 --------------------------
 
-For high-content screening datasets, the metadata about all fields of views
+For high-content screening datasets, the metadata about all images
 under a given well can be found under the "well" key in the attributes of the
 well group.
 
 The `well` dictionary MUST contain an `images` key whose value MUST be a list of JSON objects
-specifying all fields of views for a given well. Each image object MUST contain a
-`path` key whose value MUST be a string specifying the path to the field of view. The `path`
+specifying all images for a given well. Each image object MUST contain a
+`path` key whose value MUST be a string specifying the path to the image. The `path`
 MUST contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate
 of any other `path` in the `images` list. If multiple acquisitions were performed in the plate,
 it MUST contain an `acquisition` key whose value MUST be an integer identifying the acquisition
@@ -499,18 +498,18 @@ which MUST match one of the acquisition JSON objects defined in the plate metada
 The `well` dictionary SHOULD contain a `version` key whose value MUST be a string specifying the
 version of the well specification.
 
-For example the following JSON object defines a well with four fields of
-view. The first two fields of view were part of the first acquisition while
-the last two fields of view were part of the second acquisition.
+For example the following JSON object defines a well with four images.
+The first two images were part of the first acquisition while
+the last two images were part of the second acquisition.
 
 <pre class=include-code>
 path: examples/well_strict/well_4fields.json
 highlight: json
 </pre>
 
-The following JSON object defines a well with two fields of view in a plate with
-four acquisitions. The first field is part of the first acquisition, and the second
-field is part of the last acquisition.
+The following JSON object defines a well with two images in a plate with
+four acquisitions. The first image is part of the first acquisition, and the second
+image is part of the last acquisition.
 
 <pre class=include-code>
 path: examples/well_strict/well_2fields.json

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -193,6 +193,15 @@ dataset. Three groups MUST be defined above the images:
 A well row group SHOULD NOT be present if there are no images in the well row.
 A well group SHOULD NOT be present if there are no images in the well.
 
+Note: Trade-offs on how data is structured per well:
+Field of views of the microscope MAY be saved as individual images in each
+well to allow for maximal flexibility regarding translations between field of views.
+Having wells with many individual images does not scale for visualisation of
+large plates. Visualisation tools would then need to read all the tiny pyramid
+files for each field of view to create overviews and this IO performance becomes
+a big limiting factor. In that case, all the field of views SHOULD be saved as
+a single, combined image. In that way, the pyramid chunks can be kept at a
+reasonable size for low-resolution representations of a well.
 
 <pre>
 .                             # Root folder, potentially in S3,


### PR DESCRIPTION
I would like to suggest a change to the wording of the OME-NGFF HCS plate specification and add some recommendations about performance for visualization vs. structure of image pyramids per well. Specifically, I propose that we explicitly allow for whole wells being saved as a single image as part of the OME-NGFF spec. As a conclusion of this, the components of the wells would be images, not field of views (because the image could consist of multiple field of views stitched together already).

## Motivation
We would like to use OME-Zarr files to store TB-sized multi-channel, 3D high content imaging data in the HCS format. We are building an open-source image processing pipeline to process data in HCS OME-Zarr called [Fractal](https://github.com/fractal-analytics-platform/fractal). One of the benefits of saving such large datasets in OME-Zarrs is the possibility of interactive image visualization, e.g. in the napari viewer. When we were testing the scalability of this approach to large HCS plates, we discovered issues with saving all the field of views of the microscope as separate field of views in each well of the OME-Zarr file.
We started the discussion about this topic here: https://github.com/ome/ome-zarr-py/issues/200
The discussion on the approach of saving single images per well starts here in more detail: https://github.com/ome/ome-zarr-py/issues/200#issuecomment-1167251097

To very briefly summarize it:
By saving many field of views (FOVs) per well as separate images with the whole pyramid hierarchy leads to very suboptimal IO challenges. To visualize plates at low resolution, a tiny pyramid file needs to be loaded for each field of view. When a plate has >1000 field of views across all its wells, this becomes very, very slow. Even for a case with just 72 field of views and just 3 pyramid levels, loading was already 8 times slower with the FOVs saved as separate image pyramids vs. a single image pyramid. This seems to be quite a fundamental issue of how fast many small files vs. a single large file can be accessed and would likely get worse when using object storage vs classical file systems. See further details in the issues above 
<img width="1056" alt="OME_Zarr_Pyramids" src="https://user-images.githubusercontent.com/18033446/187205722-0672b50b-d79c-47f8-9720-51db2c19cc00.png">

Thus, our solution to this has been to store our wells as a single, fused images for each well. In discussions on this issue, there was an openness to this approach being part of the spec. Thus, I have created this PR to suggest a change that would explicitly allow this and mentions the trade-offs. I hope this PR can be the place to discuss this further and see whether it can make it into the ome-ngff spec.

## Open questions
How should we specify the trade-offs? I'm proposing a "Note" here, but open to other implementations. Also, is this specification of Note correct? Does it work for multi-line paragraphs?

Is the explanation of the trade-offs understandable? See here: 20261ace44a4be387f02225fbef93ef8281b1aa5

> Note: Trade-offs on how data is structured per well:
> Field of views of the microscope MAY be saved as individual images in each
> well to allow for maximal flexibility regarding translations between field of views.
> Having wells with many individual images does not scale for visualisation of
> large plates. Visualisation tools would then need to read all the tiny pyramid
> files for each field of view to create overviews and this IO performance becomes
> a big limiting factor. In that case, all the field of views SHOULD be saved as
> a single, combined image. In that way, the pyramid chunks can be kept at a
> reasonable size for low-resolution representations of a well.

I think it is important to get away from the field of view naming in the spec when wells can be collections of images. But there are two keys in the plate metadata that contain the name field. How should one proceed with these?
Specifically, `maximumfieldcount` (does it describe max field of views per well? Or in total? ⇒ is the wording of images per well correct? Or would it be images in the whole plate (though then what is “max”, isn’t that just a count)?) and `field_count` (is that per well or per plate? It says “fields per view” ⇒ what is a view?)