### PR TITLE
Ngff tools table

### DIFF
--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -161,7 +161,8 @@ The following versions of each viewer were used in testing:
     </tr>
     <tr>
       <td>multiscales coordinateTransformations (v0.4)</td>
-      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a></td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a>
+       translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>n</td>
       <td>n</td>
       <td>?</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -83,7 +83,12 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
   </thead>
   <tbody>
-  <th>omero info</th>
+    <tr>
+      <td>omero info</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+    </tr>
     <tr>
       <td>Z-downsampling</td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -134,7 +134,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
     </tr>
     <tr>
-      <td>datasets.coordinateTransformations (v0.4)</td>
+      <td>datasets coordinateTransformations (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr">13457537.zarr</a>
         translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y (scale, translate)</td>
@@ -145,7 +145,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>?</td>
     </tr>
     <tr>
-      <td>multiscales.coordinateTransformations (v0.4)</td>
+      <td>multiscales coordinateTransformations (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a></td>
       <td>n</td>
       <td>n</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -1,7 +1,9 @@
 # OME-NGFF tools
 
 Various tools are available for viewing and working with OME-NGFF data.
-The following table documents which features of the OME-NGFF spec are supported by which tools:
+The following tables document which features of the OME-NGFF spec are supported by which tools.
+
+## Viewers
 
 | viewer | Z-downsampling                                  | omero info | multiscales factor not=2                           | URL (not s3)                                               | v0.3 axes | 3D view | labels | HCS plate |
 | ------ | ----------------------------------------------- | ---------- | -------------------------------------------------- | ---------------------------------------------------------- | --------- | ------- | ------ | --------- |
@@ -10,7 +12,6 @@ The following table documents which features of the OME-NGFF spec are supported 
 | MoBIE  | y                                               | n          | y                                                  | [n](https://github.com/mobie/mobie-viewer-fiji/issues/351) | n         | y       | y      | n         |
 
 1. napari 3D view only supported for lowest level of multiscales pyramid
-
 
 <table>
   <thead>
@@ -24,17 +25,19 @@ The following table documents which features of the OME-NGFF spec are supported 
       <th>3D view</th>
       <th>labels</th>
       <th>HCS plate</th>
+      <th>bioformats2raw.layout</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>napari</td>
+      <td><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
-      <td>y (1)</td>
+      <td>y (2)</td>
+      <td>y</td>
       <td>y</td>
       <td>y</td>
     </tr>
@@ -48,18 +51,23 @@ The following table documents which features of the OME-NGFF spec are supported 
       <td>n</td>
       <td>n</td>
       <td>y</td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
     </tr>
     <tr>
-      <td>MoBIE</td>
+      <td><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</td>
       <td>y</td>
       <td>n</td>
       <td>y</td>
-      <td><a href="https://github.com/mobie/mobie-viewer-fiji/issues/351">n</a></td>
+      <td>y</td>
       <td>n</td>
       <td>y</td>
       <td>y</td>
+      <td>n</td>
       <td>n</td>
     </tr>
   </tbody>
 </table>
 
+1. <a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> plugin for <a href="https://napari.org">napari</a> uses <a href="https://github.com/ome/ome-zarr-py/">ome-zarr-py</a>
+2. napari 3D view only supported for lowest level of multiscales pyramid
+3. MoBIE: Open with `Plugins > BigDataViewer > OME-Zarr > Open OME-Zarr From...`

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -19,9 +19,20 @@ The following tables document which features of the OME-NGFF spec are supported 
       <th><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</th>
       <th><a href="https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></th>
       <th><a href="https://webknossos.org">webKnossos</a></th>
+      <th><a href="https://www.openmicroscopy.org/omero/">OMERO</a></th>
     </tr>
   </thead>
   <tbody>
+  <tr>
+      <td>Viewer type/language</td>
+      <td></td>
+      <td>desktop/Python</td>
+      <td>browser/JavaScript</td>
+      <td>desktop/Java</td>
+      <td>browser/notebook/Python</td>
+      <td>browser client + server</td>
+      <td>various clients + server</td>
+    </tr>
     <tr>
       <td>Z-downsampling</td>
       <td></td>
@@ -30,6 +41,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>y</td>
+      <td>n</td>
     </tr>
     <tr>
       <td>omero info</td>
@@ -39,6 +51,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
       <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/546">n</a></td>
       <td>n</td>
+      <td>n?</td>
     </tr>
     <tr>
       <td>multiscales factor not=2</td>
@@ -48,6 +61,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>y</td>
+      <td>y?</td>
     </tr>
     <tr>
       <td>axes (v0.3)</td>
@@ -57,6 +71,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>n</td>
+      <td>?</td>
     </tr>
     <tr>
       <td>v0.4 axes (v0.4)</td>
@@ -66,6 +81,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>y</td>
+      <td>?</td>
     </tr>
     <tr>
       <td>3D view</td>
@@ -75,6 +91,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>y</td>
+      <td>n</td>
     </tr>
     <tr>
       <td>labels</td>
@@ -84,6 +101,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/547">n</a></td>
       <td>y</td>
+      <td>?</td>
     </tr>
     <tr>
       <td>HCS plate</td>
@@ -93,6 +111,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
       <td>n</td>
       <td>n</td>
+      <td>y</td>
     </tr>
     <tr>
       <td>bioformats2raw.layout</td>
@@ -102,10 +121,12 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td><span style="color: red">X</span></td>
       <td>n</td>
       <td>n</td>
+      <td>y</td>
     </tr>
     <tr>
       <td>multiple 'multiscales'</td>
       <td></td>
+      <td>n</td>
       <td>n</td>
       <td>n</td>
       <td>n</td>
@@ -121,6 +142,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>?</td>
       <td>y (scale)</td>
       <td>y (scale)</td>
+      <td>?</td>
     </tr>
     <tr>
       <td>multiscales.coordinateTransformations (v0.4)</td>
@@ -130,15 +152,17 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>?</td>
       <td>?</td>
       <td>?</td>
+      <td>?</td>
     </tr>
     <tr>
-      <td>open multiple images (URLs)</td>
+      <td>overlay multiple images</td>
       <td></td>
       <td>y</td>
       <td>n</td>
       <td>?</td>
       <td>?</td>
       <td>y</td>
+      <td>n</td>
     </tr>
     <tr>
       <td>multiple Channels</td>
@@ -147,6 +171,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>n</td>
+      <td>y</td>
       <td>y</td>
     </tr>
     <tr>
@@ -157,6 +182,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>n</td>
       <td>n</td>
+      <td>y</td>
     </tr>
   </tbody>
 </table>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -66,7 +66,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
     </tr>
     <tr>
-      <td><a href="(https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></td>
+      <td><a href="https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></td>
       <td>y</td>
       <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/546">n</a></td>
       <td>y</td>
@@ -104,7 +104,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <th><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</th>
       <th><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></th>
       <th><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</th>
-      <th><a href="(https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></th>
+      <th><a href="https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></th>
       <th><a href="https://webknossos.org">webKnossos</a></th>
     </tr>
   </thead>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -101,6 +101,7 @@ The following tables document which features of the OME-NGFF spec are supported 
   <thead>
     <tr>
       <th></th>
+      <th>Sample data</th>
       <th><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</th>
       <th><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></th>
       <th><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</th>
@@ -111,6 +112,7 @@ The following tables document which features of the OME-NGFF spec are supported 
   <tbody>
     <tr>
       <td>Z-downsampling</td>
+      <td></td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/pull/71">n</a></td>
       <td>y</td>
@@ -119,6 +121,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>omero info</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr">6001240.zarr</a></td>
       <td>y</td>
       <td>y</td>
       <td>n</td>
@@ -127,6 +130,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>multiscales factor not=2</td>
+      <td></td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/101">n</a></td>
       <td>y</td>
@@ -135,6 +139,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>URL (not s3)</td>
+      <td></td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
@@ -143,6 +148,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>v0.3 axes</td>
+      <td></td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
@@ -151,6 +157,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>3D view</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr">6001240.zarr</a></td>
       <td>y (2)</td>
       <td>n</td>
       <td>y</td>
@@ -159,6 +166,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>labels</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0052A/5514375.zarr">5514375.zarr</a></td>
       <td>y</td>
       <td>n</td>
       <td>y</td>
@@ -167,6 +175,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>HCS plate</td>
+      <td></td>
       <td>y</td>
       <td>y</td>
       <td>n</td>
@@ -175,6 +184,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>bioformats2raw.layout</td>
+      <td></td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
       <td>n</td>
@@ -183,6 +193,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>multiple 'multiscales'</td>
+      <td></td>
       <td>n</td>
       <td>n</td>
       <td>n</td>
@@ -191,6 +202,8 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>coordinateTransformations (datasets)</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr">13457537.zarr</a>
+        translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y (translate)</td>
       <td>n</td>
       <td>n</td>
@@ -199,6 +212,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>coordinateTransformations (multiscales)</td>
+      <td></td>
       <td>n</td>
       <td>n</td>
       <td>?</td>
@@ -207,14 +221,16 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>open multiple images (URLs)</td>
-      <td>n</td>
+      <td></td>
       <td>y</td>
+      <td>n</td>
       <td>?</td>
       <td>?</td>
       <td>y</td>
     </tr>
     <tr>
       <td>Support multi C/T</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y</td>
       <td>y</td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -5,21 +5,26 @@ The following tables document which features of the OME-NGFF spec are supported 
 
 ## Viewers
 
-1. <a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> plugin for <a href="https://napari.org">napari</a> uses <a href="https://github.com/ome/ome-zarr-py/">ome-zarr-py</a>
-2. napari 3D view only supported for lowest level of multiscales pyramid
-3. MoBIE: Open with `Plugins > BigDataViewer > OME-Zarr > Open OME-Zarr From...`
+The following versions of each viewer were used in testing:
+
+ - <a href="https://napari.org">napari</a> 0.4.16 with plugin <a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a>0.5.2 and <a href="https://github.com/ome/ome-zarr-py/">ome-zarr</a>0.6.0.
+ - <a href="https://github.com/hms-dbmi/vizarr/">vizarr</a> using <a href="https://hms-dbmi.github.io/vizarr">current viewer</a> October 2022. Open via URL - see <a href="https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr">example</a>.
+ - <a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> plugin for ImageJ/Fiji. Open with `Plugins > BigDataViewer > OME-Zarr > Open OME-Zarr From...`
+ - <a href="https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a>. Use in a python notebook, or open via URL: See <a href="https://kitware.github.io/itk-vtk-viewer/app/?rotate=false&fileToLoad=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr">example</a>.
+ - <a href="https://webknossos.org">webKnossos</a> version 19988.
+ - <a href="https://www.openmicroscopy.org/omero/">OMERO</a> with BioFormats <a href="https://github.com/ome/ZarrReader">ZarrReader</a> 0.2.0.
 
 <table>
   <thead>
     <tr>
       <th></th>
       <th>Sample data</th>
-      <th><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</th>
-      <th><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></th>
-      <th><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</th>
-      <th><a href="https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></th>
-      <th><a href="https://webknossos.org">webKnossos</a></th>
-      <th><a href="https://www.openmicroscopy.org/omero/">OMERO</a></th>
+      <th>napari</th>
+      <th>vizarr</th>
+      <th>MoBIE</th>
+      <th>itkwidgets</th>
+      <th>webKnossos</th>
+      <th>OMERO</th>
     </tr>
   </thead>
   <tbody>
@@ -86,7 +91,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     <tr>
       <td>3D view</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr">6001240.zarr</a></td>
-      <td>y (2)</td>
+      <td>y (1)</td>
       <td>n</td>
       <td>y</td>
       <td>y</td>
@@ -186,3 +191,8 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
   </tbody>
 </table>
+
+
+
+1. napari 3D view only supported for lowest level of multiscales pyramid
+

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -123,7 +123,7 @@ The following versions of each viewer were used in testing:
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr">9838562.zarr</a></td>
       <td><a href="https://github.com/ome/napari-ome-zarr/issues/71">n</a></td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
-      <td><span style="color: red">X</span></td>
+      <td>n</td>
       <td>n</td>
       <td>n</td>
       <td>y</td>
@@ -139,15 +139,25 @@ The following versions of each viewer were used in testing:
       <td>n</td>
     </tr>
     <tr>
-      <td>datasets coordinateTransformations (v0.4)</td>
+      <td>datasets coordinateTransformations [scale] (v0.4)</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
+      <td>y</td>
+      <td>n</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>?</td>
+    </tr>
+    <tr>
+      <td>datasets coordinateTransformations [translation] (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr">13457537.zarr</a>
         translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
-      <td>y (scale, translate)</td>
+      <td>y</td>
       <td>n</td>
-      <td>?</td>
-      <td>y (scale)</td>
-      <td>y (scale)</td>
-      <td>?</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
     </tr>
     <tr>
       <td>multiscales coordinateTransformations (v0.4)</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -39,23 +39,10 @@ The following table documents which features of the OME-NGFF spec are supported 
       <td>y</td>
     </tr>
     <tr>
-      <td>vizarr</td>
-      <td>
-        <a
-          href="https://github.com/hms-dbmi/vizarr/pull/71"
-          >n</a
-        >
-      </td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/pull/71">n</a></td>
       <td>y</td>
-      <td>
-        <a
-          href="https://github.com/hms-dbmi/vizarr/issues/101"
-          data-hovercard-type="issue"
-          data-hovercard-url="/hms-dbmi/vizarr/issues/101/hovercard"
-          data-turbo-frame=""
-          >n</a
-        >
-      </td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/issues/101">n</a></td>
       <td>y</td>
       <td>y</td>
       <td>n</td>
@@ -67,15 +54,7 @@ The following table documents which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>n</td>
       <td>y</td>
-      <td>
-        <a
-          href="https://github.com/mobie/mobie-viewer-fiji/issues/351"
-          data-hovercard-type="issue"
-          data-hovercard-url="/mobie/mobie-viewer-fiji/issues/351/hovercard"
-          data-turbo-frame=""
-          >n</a
-        >
-      </td>
+      <td><a href="https://github.com/mobie/mobie-viewer-fiji/issues/351">n</a></td>
       <td>n</td>
       <td>y</td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -99,7 +99,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr">9838562.zarr</a></td>
       <td><a href="https://github.com/ome/napari-ome-zarr/issues/71">n</a></td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
-      <td>n</td>
+      <td><span style="color: red">X</span></td>
       <td>n</td>
       <td>n</td>
     </tr>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -160,15 +160,25 @@ The following versions of each viewer were used in testing:
       <td>n</td>
     </tr>
     <tr>
-      <td>multiscales coordinateTransformations (v0.4)</td>
+      <td>multiscales coordinateTransformations [scale] (v0.4)</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a></td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+    </tr>
+    <tr>
+      <td>multiscales coordinateTransformations [translation] (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a>
        translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>n</td>
       <td>n</td>
-      <td>?</td>
-      <td>?</td>
-      <td>?</td>
-      <td>?</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
     </tr>
     <tr>
       <td>overlay multiple images</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -181,5 +181,45 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
       <td>n</td>
     </tr>
+    <tr>
+      <td>multiple 'multiscales'</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+      <td>n</td>
+    </tr>
+    <tr>
+      <td>coordinateTransformations (datasets)</td>
+      <td>y (translate)</td>
+      <td>n</td>
+      <td>n</td>
+      <td>?</td>
+      <td>?</td>
+    </tr>
+    <tr>
+      <td>coordinateTransformations (multiscales)</td>
+      <td>n</td>
+      <td>n</td>
+      <td>?</td>
+      <td>?</td>
+      <td>?</td>
+    </tr>
+    <tr>
+      <td>open multiple images (URLs)</td>
+      <td>n</td>
+      <td>y</td>
+      <td>?</td>
+      <td>?</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>Support multi C/T</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>?</td>
+      <td>n</td>
+    </tr>
   </tbody>
 </table>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -134,6 +134,14 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
     </tr>
     <tr>
+      <td>URL (not s3)</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+    </tr>
+    <tr>
       <td>v0.3 axes</td>
       <td>y</td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -185,7 +185,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     <tr>
       <td>bioformats2raw.layout</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr">9838562.zarr</a></td>
-      <td>y</td>
+      <td><a href="https://github.com/ome/napari-ome-zarr/issues/71">n</a></td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
       <td>n</td>
       <td>n</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -138,15 +138,6 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
     </tr>
     <tr>
-      <td>URL (not s3)</td>
-      <td></td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-    </tr>
-    <tr>
       <td>v0.3 axes</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr">9836998.zarr</a></td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -139,7 +139,11 @@ The following versions of each viewer were used in testing:
       <td>n</td>
     </tr>
     <tr>
-      <td>datasets coordinateTransformations [scale] (v0.4)</td>
+      <td>
+        <b>scale</b> within
+        <a href="https://ngff.openmicroscopy.org/0.4/#trafo-md">coordinateTransformations</a>
+        on datasets (v0.4)
+      </td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y</td>
       <td>n</td>
@@ -149,7 +153,11 @@ The following versions of each viewer were used in testing:
       <td>?</td>
     </tr>
     <tr>
-      <td>datasets coordinateTransformations [translation] (v0.4)</td>
+      <td>
+        <b>translation</b> within
+        <a href="https://ngff.openmicroscopy.org/0.4/#trafo-md">coordinateTransformations</a>
+        on datasets (v0.4)
+      </td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr">13457537.zarr</a>
         translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y</td>
@@ -160,7 +168,11 @@ The following versions of each viewer were used in testing:
       <td>n</td>
     </tr>
     <tr>
-      <td>multiscales coordinateTransformations [scale] (v0.4)</td>
+      <td>
+        <b>scale</b> within
+        <a href="https://ngff.openmicroscopy.org/0.4/#trafo-md">coordinateTransformations</a>
+        on <a href="https://ngff.openmicroscopy.org/0.4/#multiscale-md">multiscales</a> (v0.4)
+      </td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a></td>
       <td>n</td>
       <td>n</td>
@@ -170,7 +182,11 @@ The following versions of each viewer were used in testing:
       <td>n</td>
     </tr>
     <tr>
-      <td>multiscales coordinateTransformations [translation] (v0.4)</td>
+      <td>
+        <b>translation</b> within
+        <a href="https://ngff.openmicroscopy.org/0.4/#trafo-md">coordinateTransformations</a>
+        on <a href="https://ngff.openmicroscopy.org/0.4/#multiscale-md">multiscales</a> (v0.4)
+      </td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a>
        translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>n</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -40,7 +40,7 @@ The following versions of each viewer were used in testing:
     </tr>
     <tr>
       <td>Z-downsampling</td>
-      <td></td>
+      <td><a href="https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z.zarr">9836832_z.zarr</a></td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/pull/71">n</a></td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -148,7 +148,16 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>v0.3 axes</td>
-      <td></td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr">9836998.zarr</a></td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+    </tr>
+    <tr>
+      <td>v0.4 axes</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y</td>
       <td>y</td>
       <td>y</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -71,3 +71,60 @@ The following tables document which features of the OME-NGFF spec are supported 
 1. <a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> plugin for <a href="https://napari.org">napari</a> uses <a href="https://github.com/ome/ome-zarr-py/">ome-zarr-py</a>
 2. napari 3D view only supported for lowest level of multiscales pyramid
 3. MoBIE: Open with `Plugins > BigDataViewer > OME-Zarr > Open OME-Zarr From...`
+
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</th>
+      <th><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></th>
+      <th><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</th>
+    </tr>
+  </thead>
+  <tbody>
+  <th>omero info</th>
+    <tr>
+      <td>Z-downsampling</td>
+      <td>y</td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/pull/71">n</a></td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>multiscales factor not=2</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+    </tr>
+    <tr>
+      <td>v0.3 axes</td>
+      <td>y</td>
+      <td>y</td>
+      <td>?</td>
+    </tr>
+    <tr>
+      <td>3D view</td>
+      <td>y (2)</td>
+      <td>n</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>labels</td>
+      <td>y</td>
+      <td>n</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>HCS plate</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+    </tr>
+    <tr>
+      <td>bioformats2raw.layout</td>
+      <td>y</td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
+      <td>n</td>
+    </tr>
+  </tbody>
+</table>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -65,6 +65,30 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
       <td>n</td>
     </tr>
+    <tr>
+      <td><a href="(https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></td>
+      <td>y</td>
+      <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/546">n</a></td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/547">n</a></td>
+      <td>n</td>
+      <td>n</td>
+    </tr>
+    <tr>
+      <td><a href="https://webknossos.org">webKnossos</a></td>
+      <td>y</td>
+      <td>n</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+      <td>n</td>
+    </tr>
   </tbody>
 </table>
 
@@ -80,29 +104,39 @@ The following tables document which features of the OME-NGFF spec are supported 
       <th><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</th>
       <th><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></th>
       <th><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</th>
+      <th><a href="(https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></th>
+      <th><a href="https://webknossos.org">webKnossos</a></th>
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>omero info</td>
-      <td>y</td>
-      <td>y</td>
-      <td>n</td>
-    </tr>
     <tr>
       <td>Z-downsampling</td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/pull/71">n</a></td>
       <td>y</td>
+      <td>y</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>omero info</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+      <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/546">n</a></td>
+      <td>n</td>
     </tr>
     <tr>
       <td>multiscales factor not=2</td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/101">n</a></td>
       <td>y</td>
+      <td>y</td>
+      <td>y</td>
     </tr>
     <tr>
       <td>v0.3 axes</td>
+      <td>y</td>
+      <td>y</td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
@@ -112,11 +146,15 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y (2)</td>
       <td>n</td>
       <td>y</td>
+      <td>y</td>
+      <td>y</td>
     </tr>
     <tr>
       <td>labels</td>
       <td>y</td>
       <td>n</td>
+      <td>y</td>
+      <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/547">n</a></td>
       <td>y</td>
     </tr>
     <tr>
@@ -124,11 +162,15 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
       <td>y</td>
       <td>n</td>
+      <td>n</td>
+      <td>n</td>
     </tr>
     <tr>
       <td>bioformats2raw.layout</td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
+      <td>n</td>
+      <td>n</td>
       <td>n</td>
     </tr>
   </tbody>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -43,9 +43,6 @@ The following table documents which features of the OME-NGFF spec are supported 
       <td>
         <a
           href="https://github.com/hms-dbmi/vizarr/pull/71"
-          data-hovercard-type="pull_request"
-          data-hovercard-url="/hms-dbmi/vizarr/pull/71/hovercard"
-          data-turbo-frame=""
           >n</a
         >
       </td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -1,0 +1,89 @@
+# OME-NGFF tools
+
+Various tools are available for viewing and working with OME-NGFF data.
+The following table documents which features of the OME-NGFF spec are supported by which tools:
+
+| viewer | Z-downsampling                                  | omero info | multiscales factor not=2                           | URL (not s3)                                               | v0.3 axes | 3D view | labels | HCS plate |
+| ------ | ----------------------------------------------- | ---------- | -------------------------------------------------- | ---------------------------------------------------------- | --------- | ------- | ------ | --------- |
+| napari | y                                               | y          | y                                                  | y                                                          | y         | y (1)   | y      | y         |
+| vizarr | [n](https://github.com/hms-dbmi/vizarr/pull/71) | y          | [n](https://github.com/hms-dbmi/vizarr/issues/101) | y                                                          | y         | n       | n      | y         |
+| MoBIE  | y                                               | n          | y                                                  | [n](https://github.com/mobie/mobie-viewer-fiji/issues/351) | n         | y       | y      | n         |
+
+1. napari 3D view only supported for lowest level of multiscales pyramid
+
+
+<table>
+  <thead>
+    <tr>
+      <th>viewer</th>
+      <th>Z-downsampling</th>
+      <th>omero info</th>
+      <th>multiscales factor not=2</th>
+      <th>URL (not s3)</th>
+      <th>v0.3 axes</th>
+      <th>3D view</th>
+      <th>labels</th>
+      <th>HCS plate</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>napari</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>y (1)</td>
+      <td>y</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>vizarr</td>
+      <td>
+        <a
+          href="https://github.com/hms-dbmi/vizarr/pull/71"
+          data-hovercard-type="pull_request"
+          data-hovercard-url="/hms-dbmi/vizarr/pull/71/hovercard"
+          data-turbo-frame=""
+          >n</a
+        >
+      </td>
+      <td>y</td>
+      <td>
+        <a
+          href="https://github.com/hms-dbmi/vizarr/issues/101"
+          data-hovercard-type="issue"
+          data-hovercard-url="/hms-dbmi/vizarr/issues/101/hovercard"
+          data-turbo-frame=""
+          >n</a
+        >
+      </td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+      <td>n</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>MoBIE</td>
+      <td>y</td>
+      <td>n</td>
+      <td>y</td>
+      <td>
+        <a
+          href="https://github.com/mobie/mobie-viewer-fiji/issues/351"
+          data-hovercard-type="issue"
+          data-hovercard-url="/mobie/mobie-viewer-fiji/issues/351/hovercard"
+          data-turbo-frame=""
+          >n</a
+        >
+      </td>
+      <td>n</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
+    </tr>
+  </tbody>
+</table>
+

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -175,7 +175,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>HCS plate</td>
-      <td></td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0001A/2551.zarr">idr0001</a></td>
       <td>y</td>
       <td>y</td>
       <td>n</td>
@@ -184,7 +184,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>bioformats2raw.layout</td>
-      <td></td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr">9838562.zarr</a></td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
       <td>n</td>
@@ -212,7 +212,7 @@ The following tables document which features of the OME-NGFF spec are supported 
     </tr>
     <tr>
       <td>coordinateTransformations (multiscales)</td>
-      <td></td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a></td>
       <td>n</td>
       <td>n</td>
       <td>?</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -9,7 +9,7 @@ The following tables document which features of the OME-NGFF spec are supported 
 | ------ | ----------------------------------------------- | ---------- | -------------------------------------------------- | ---------------------------------------------------------- | --------- | ------- | ------ | --------- |
 | napari | y                                               | y          | y                                                  | y                                                          | y         | y (1)   | y      | y         |
 | vizarr | [n](https://github.com/hms-dbmi/vizarr/pull/71) | y          | [n](https://github.com/hms-dbmi/vizarr/issues/101) | y                                                          | y         | n       | n      | y         |
-| MoBIE  | y                                               | n          | y                                                  | [n](https://github.com/mobie/mobie-viewer-fiji/issues/351) | n         | y       | y      | n         |
+| MoBIE  | y                                               | n          | y                                                  | [n](https://github.com/mobie/mobie-viewer-fiji/issues/351) | y         | y       | y      | n         |
 
 1. napari 3D view only supported for lowest level of multiscales pyramid
 
@@ -59,7 +59,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
       <td>y</td>
       <td>y</td>
-      <td>n</td>
+      <td>y</td>
       <td>y</td>
       <td>y</td>
       <td>n</td>
@@ -98,14 +98,14 @@ The following tables document which features of the OME-NGFF spec are supported 
     <tr>
       <td>multiscales factor not=2</td>
       <td>y</td>
+      <td><a href="https://github.com/hms-dbmi/vizarr/issues/101">n</a></td>
       <td>y</td>
-      <td>n</td>
     </tr>
     <tr>
       <td>v0.3 axes</td>
       <td>y</td>
       <td>y</td>
-      <td>?</td>
+      <td>y</td>
     </tr>
     <tr>
       <td>3D view</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -50,7 +50,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
     </tr>
     <tr>
-      <td>v0.3 axes</td>
+      <td>axes (v0.3)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr">9836998.zarr</a></td>
       <td>y</td>
       <td>y</td>
@@ -59,7 +59,7 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
     </tr>
     <tr>
-      <td>v0.4 axes</td>
+      <td>v0.4 axes (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y</td>
       <td>y</td>
@@ -113,17 +113,17 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>n</td>
     </tr>
     <tr>
-      <td>coordinateTransformations (datasets)</td>
+      <td>datasets.coordinateTransformations (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr">13457537.zarr</a>
         translate onto <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
-      <td>y (translate)</td>
-      <td>n</td>
+      <td>y (scale, translate)</td>
       <td>n</td>
       <td>?</td>
-      <td>?</td>
+      <td>y (scale)</td>
+      <td>y (scale)</td>
     </tr>
     <tr>
-      <td>coordinateTransformations (multiscales)</td>
+      <td>multiscales.coordinateTransformations (v0.4)</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr">13457539.zarr</a></td>
       <td>n</td>
       <td>n</td>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -238,12 +238,21 @@ The following tables document which features of the OME-NGFF spec are supported 
       <td>y</td>
     </tr>
     <tr>
-      <td>Support multi C/T</td>
+      <td>multiple Channels</td>
       <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
       <td>y</td>
       <td>y</td>
       <td>y</td>
-      <td>?</td>
+      <td>n</td>
+      <td>y</td>
+    </tr>
+    <tr>
+      <td>multiple Time-points</td>
+      <td><a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr">13457227.zarr</a></td>
+      <td>y</td>
+      <td>y</td>
+      <td>y</td>
+      <td>n</td>
       <td>n</td>
     </tr>
   </tbody>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -24,12 +24,12 @@ The following tables document which features of the OME-NGFF spec are supported 
   </thead>
   <tbody>
   <tr>
-      <td>Viewer type/language</td>
+      <td>Viewer type, language</td>
       <td></td>
-      <td>desktop/Python</td>
-      <td>browser/JavaScript</td>
-      <td>desktop/Java</td>
-      <td>browser/notebook/Python</td>
+      <td>desktop, Python</td>
+      <td>browser, JavaScript</td>
+      <td>desktop, Java</td>
+      <td>notebook, Python</td>
       <td>browser client + server</td>
       <td>various clients + server</td>
     </tr>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -5,97 +5,9 @@ The following tables document which features of the OME-NGFF spec are supported 
 
 ## Viewers
 
-| viewer | Z-downsampling                                  | omero info | multiscales factor not=2                           | URL (not s3)                                               | v0.3 axes | 3D view | labels | HCS plate |
-| ------ | ----------------------------------------------- | ---------- | -------------------------------------------------- | ---------------------------------------------------------- | --------- | ------- | ------ | --------- |
-| napari | y                                               | y          | y                                                  | y                                                          | y         | y (1)   | y      | y         |
-| vizarr | [n](https://github.com/hms-dbmi/vizarr/pull/71) | y          | [n](https://github.com/hms-dbmi/vizarr/issues/101) | y                                                          | y         | n       | n      | y         |
-| MoBIE  | y                                               | n          | y                                                  | [n](https://github.com/mobie/mobie-viewer-fiji/issues/351) | y         | y       | y      | n         |
-
-1. napari 3D view only supported for lowest level of multiscales pyramid
-
-<table>
-  <thead>
-    <tr>
-      <th>viewer</th>
-      <th>Z-downsampling</th>
-      <th>omero info</th>
-      <th>multiscales factor not=2</th>
-      <th>URL (not s3)</th>
-      <th>v0.3 axes</th>
-      <th>3D view</th>
-      <th>labels</th>
-      <th>HCS plate</th>
-      <th>bioformats2raw.layout</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> (1)</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y (2)</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/hms-dbmi/vizarr/">vizarr</a></td>
-      <td><a href="https://github.com/hms-dbmi/vizarr/pull/71">n</a></td>
-      <td>y</td>
-      <td><a href="https://github.com/hms-dbmi/vizarr/issues/101">n</a></td>
-      <td>y</td>
-      <td>y</td>
-      <td>n</td>
-      <td>n</td>
-      <td>y</td>
-      <td><a href="https://github.com/hms-dbmi/vizarr/issues/149">n</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/mobie/mobie-viewer-fiji/">MoBIE</a> (3)</td>
-      <td>y</td>
-      <td>n</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>n</td>
-      <td>n</td>
-    </tr>
-    <tr>
-      <td><a href="https://itkwidgets.readthedocs.io/en/latest">itkwidgets</a></td>
-      <td>y</td>
-      <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/546">n</a></td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td><a href="https://github.com/InsightSoftwareConsortium/itkwidgets/issues/547">n</a></td>
-      <td>n</td>
-      <td>n</td>
-    </tr>
-    <tr>
-      <td><a href="https://webknossos.org">webKnossos</a></td>
-      <td>y</td>
-      <td>n</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>y</td>
-      <td>n</td>
-      <td>n</td>
-    </tr>
-  </tbody>
-</table>
-
 1. <a href="https://github.com/ome/napari-ome-zarr/">napari-ome-zarr</a> plugin for <a href="https://napari.org">napari</a> uses <a href="https://github.com/ome/ome-zarr-py/">ome-zarr-py</a>
 2. napari 3D view only supported for lowest level of multiscales pyramid
 3. MoBIE: Open with `Plugins > BigDataViewer > OME-Zarr > Open OME-Zarr From...`
-
 
 <table>
   <thead>

--- a/ngff-tools.md
+++ b/ngff-tools.md
@@ -60,7 +60,7 @@ The following versions of each viewer were used in testing:
     </tr>
     <tr>
       <td>multiscales factor not=2</td>
-      <td></td>
+      <td><a href="https://minio-dev.openmicroscopy.org/idr/v0.4/idr0082/9846318.zarr/0">9846318.zarr/0</a></td>
       <td>y</td>
       <td><a href="https://github.com/hms-dbmi/vizarr/issues/101">n</a></td>
       <td>y</td>


### PR DESCRIPTION
Started to look again at #71

View page at https://github.com/will-moore/ngff/blob/ngff_tools_table/ngff-tools.md

Aims of this table/documentation:

- Allow data producers and consumers to know whether a particular feature is supported in their viewer of choice
- Document the various viewers available that support OME-NGFF 
- Link to sample data that can be used for testing a particular feature - NB: some overlap here with https://idr.github.io/ome-ngff-samples/

Created a top-level `ngff-tools.md` page.
Tried tables (duplicates) in markdown format or html.
The current table is for "viewers" but I think we could possibly list other tools for producing OME-NGFF too (bioformats2raw, ome-ngff, omero-cli-zarr etc).

First questions:
 - Is this a suitable location and page format?
 - Prefer tables in markdown, but with data in a different file (e.g. yaml or csv) - but how & where to build/publish etc?
 - Also I think that the last table with the axes switched works better since it allows lots of features (rows) and we don't need so many columns (tools)
 - FYI: compare with web browser support of various JS/HTML/CSS features, with 1 table per feature: e.g. https://caniuse.com/arrow-functions 
 - Other viewers to include?

cc @manzt @constantinpape @joshmoore @sbesson 