### PR TITLE
Fix review github action, use correct variable to format comment

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -21,6 +21,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             #### Automated Review URLs
-            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/ome/ngff/${{ github.head.sha }}/latest/index.bs)
-            * [diff latest modified](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fome%2Fngff%2F${{  github.head.sha }}%2Flatest%2Findex.bs)
+            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/ome/ngff/${{ github.event.pull_request.head.sha }}/latest/index.bs)
+            * [diff latest modified](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fome%2Fngff%2F${{  github.event.pull_request.head.sha }}%2Flatest%2Findex.bs)
           edit-mode: replace


### PR DESCRIPTION
Fix (partial) for #147 

## What this fixes

This PR fixes how the links in the review comments are generated. It looks like they were using an environment variable which has started evaluating to "" (https://github.com/ome/ngff/issues/147#issuecomment-1272590619).

You can see some more evidence of this in the workflow runs for this PR: https://github.com/ivirshup/ngff/pull/2

## This PR

This PR will not have any effect until merged, since the action it modifies runs in the context of the base branch.

For evidence that this PR works, check out https://github.com/ivirshup/ngff/pull/5, which makes a PR onto a branch containing this action.

## The warnings aren't my fault I swear

The github comment action has started throwing a bunch of warnings (unrelated to this PR) due to [deprecation by github](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) of an internal component.

@joshmoore 