### PR TITLE
Require same datatype for all arrays in multiscales:datasets

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -153,7 +153,8 @@ For this example we assume an image with 5 dimensions and axes called `t,c,z,y,x
     │   ...                   # which is a folder containing chunk files which compose the array.
     ├── n                     # The name of the array is arbitrary with the ordering defined by
     │   │                     # by the "multiscales" metadata, but is often a sequence starting at 0.
-    │   │
+    │   │                     # All arrays must have the same datatype and the same number of dimensions.
+    |   | 
     │   ├── .zarray           # All image arrays must be up to 5-dimensional
     │   │                     # with the axis of type time before type channel, before spatial axes.
     │   │
@@ -365,10 +366,11 @@ The order of the entries MUST correspond to the order of dimensions of the zarr 
 If there are three spatial axes where two correspond to the image plane ("yx") and images are stacked along the other (anisotropic) axis ("z"), the spatial axes SHOULD be ordered as "zyx".
 
 Each "multiscales" dictionary MUST contain the field "datasets", which is a list of dictionaries describing the arrays storing the individual resolution levels.
-Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative
+Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative.
 to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
 
-Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
+All arrays referenced in "datasets" MUST have the same number of dimensions and MUST have the same datatype. The number of dimensions MUST NOT be more than 5 dimensions.
+The number of dimensions and order MUST correspond to number and order of "axes".
 Each dictionary in "datasets" MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
 The transformations are defined according to [[#trafo-md]]. The transformation MUST only be of type `translation` or `scale`.
 They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes, the value MUST express the scaling factor between the current resolution and the first resolution for the given axis, defaulting to 1.0 if there is no downsampling along the axis.


### PR DESCRIPTION
Fixes #2

I think it is important to include this change rather soon. Right  now data with different dtypes across the dimensions is technically valid according to the spec, but will cause issues for several implementations.
(It does not work in MoBIE; I am pretty sure the same is true for all tools based on BigDataViewer, and I suspect any tool implemented in a strongly typed language will have issues with this).