### PR TITLE
Replace link to OME logo with an https link

### DIFF
--- a/latest/header.include
+++ b/latest/header.include
@@ -11,7 +11,7 @@
 <div class="head">
 
   <!--p data-fill-with="logo"></p-->
-  <img src="http://www.openmicroscopy.org/img/logos/ome-logomark.svg"
+  <img src="https://www.openmicroscopy.org/img/logos/ome-logomark.svg"
        alt="OME logo (6 circles in a hexagon)"
        style="float:right;width:42px;height:42px;">
 


### PR DESCRIPTION
Link to the OME logo in the header was provided as non SSL http link. Replace it with an https:// link to fix mixed-content warnings on https://ngff.openmicroscopy.org/latest/

Should fix #158 