### PR TITLE
simplify multiscale and examples

### DIFF
--- a/latest/examples/multiscales_strict/multiscales_example.json
+++ b/latest/examples/multiscales_strict/multiscales_example.json
@@ -14,35 +14,39 @@
                 {
                     "path": "0",
                     "coordinateTransformations": [{
-                        // the voxel size for the first scale level (0.5 micrometer)
                         "type": "scale",
-                        "scale": [1.0, 1.0, 0.5, 0.5, 0.5]
+                        "scale": [0.1, 1.0, 0.5, 0.5, 0.5]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [0, 0, 0, 0, 0]
                     }]
                 },
                 {
                     "path": "1",
                     "coordinateTransformations": [{
-                        // the voxel size for the second scale level (downscaled by a factor of 2 -> 1 micrometer)
                         "type": "scale",
-                        "scale": [1.0, 1.0, 1.0, 1.0, 1.0]
+                        "scale": [0.1, 1.0, 1.0, 1.0, 1.0]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [0, 0, 0.25, 0.25, 0.25]
                     }]
                 },
                 {
                     "path": "2",
                     "coordinateTransformations": [{
-                        // the voxel size for the third scale level (downscaled by a factor of 4 -> 2 micrometer)
                         "type": "scale",
-                        "scale": [1.0, 1.0, 2.0, 2.0, 2.0]
+                        "scale": [0.1, 1.0, 2.0, 2.0, 2.0]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [0, 0, 0.75, 0.75, 0.75]
                     }]
                 }
             ],
-            "coordinateTransformations": [{
-                // the time unit (0.1 milliseconds), which is the same for each scale level
-                "type": "scale",
-                "scale": [0.1, 1.0, 1.0, 1.0, 1.0]
-            }],
-            "type": "gaussian",
             "metadata": {
+                "type": "gaussian",
                 "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
                 "method": "skimage.transform.pyramid_gaussian",
                 "version": "0.16.1",

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -359,31 +359,28 @@ Metadata about an image can be found under the "multiscales" key in the group-le
 "multiscales" contains a list of dictionaries where each entry describes a multiscale image.
 
 Each "multiscales" dictionary MUST contain the field "axes", see [[#axes-md]].
-The length of "axes" must be between 2 and 5 and MUST be equal to the dimensionality of the zarr arrays storing the image data (see "datasets:path").
-The "axes" MUST contain 2 or 3 entries of "type:space" and MAY contain one additional entry of "type:time" and MAY contain one additional entry of "type:channel" or a null / custom type.
+The length of "axes" must be between 2 and 5 and MUST equal the dimensionality of the zarr arrays containing the image data (see "datasets:path").
+The "axes" list MUST contain 2 or 3 entries with "type:space" and MAY contain one additional entry of "type:time" and MAY contain one additional entry of "type:channel" or a null / custom type.
 The order of the entries MUST correspond to the order of dimensions of the zarr arrays. In addition, the entries MUST be ordered by "type" where the "time" axis must come first (if present), followed by the  "channel" or custom axis (if present) and the axes of type "space".
 If there are three spatial axes where two correspond to the image plane ("yx") and images are stacked along the other (anisotropic) axis ("z"), the spatial axes SHOULD be ordered as "zyx".
 
 Each "multiscales" dictionary MUST contain the field "datasets", which is a list of dictionaries describing the arrays storing the individual resolution levels.
-Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative
-to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
+Each dictionary in "datasets" MUST contain the field "path", which is a string encoding the path to the array for this resolution relative
+to the current zarr group. The elements of "path" MUST be ordered from largest (i.e. highest resolution) to smallest.
 
-Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
-Each dictionary in "datasets" MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
-The transformations are defined according to [[#trafo-md]]. The transformation MUST only be of type `translation` or `scale`.
-They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes, the value MUST express the scaling factor between the current resolution and the first resolution for the given axis, defaulting to 1.0 if there is no downsampling along the axis.
-It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it MUST be listed after `scale` to ensure that it is given in physical coordinates.
-The length of the `scale` and `translation` array MUST be the same as the length of "axes".
-The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while being compatible with the general transformation spec.
+Downsampling routines invariably change the coordinate grid of an image by increasing the interval between sample points. This can be expressed as a scaling transformation.
+Downsampling may also shift the origin of the first sample point. This can be expressed as a translation transformation.
+These two transformations are sufficient to unambiguously express the effect of downsampling on a coordinate grid.  
 
-Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to all resolution levels in the same manner.
-The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations" and are applied after them.
-They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
+Therefore, each dictionary in "datasets" MUST contain the field "coordinateTransformations", which is a list with exactly two elements: 
+a `scale` transformation, and a `translation` transformation, defined according to [[#trafo-md]].
 
-Each "multiscales" dictionary SHOULD contain the field "name". It SHOULD contain the field "version", which indicates the version of the multiscale metadata of this image (current version is [NGFFVERSION]).
+The `translation` transform MUST be listed after the `scale` transform to ensure that it is given in physical coordinates.
+The parameters of both transformations MUST be valid with respect to the dimensionality of the arrays, e.g. if a `scale` transformation has parameters [1,1,1], then the array referenced by the aforementioned "path" field MUST have 3 dimensions.
 
-Each "multiscales" dictionary SHOULD contain the field "type", which gives the type of downscaling method used to generate the multiscale image pyramid.
-It SHOULD contain the field "metadata", which contains a dictionary with additional information about the downscaling method.
+Each "multiscales" dictionary SHOULD contain the field "name", which is a string that identifies the multiscale collection.
+Each "multiscles" dictionary MUST contain the field "version", which is a string representation of the version of the multiscale metadata of this image (current version is [NGFFVERSION]).
+Each "multiscles" dictionary MAY contain the field "metadata", which contains a dictionary with information about the downscaling method.
 
 <pre class=include-code>
 path: examples/multiscales_strict/multiscales_example.json
@@ -391,8 +388,9 @@ highlight: json
 </pre>
 
 
-If only one multiscale is provided, use it. Otherwise, the user can choose by
-name, using the first multiscale as a fallback:
+Applications that support this specification should be capable of handling multiple elements in `multiscales`. 
+For example, applications should give the user the option to choose a multiscale collection by
+name, using the first multiscale as a default:
 
 ```python
 datasets = []


### PR DESCRIPTION
This PR simplifies the multiscale metadata. A few highlights:

- No more top-level `coordinateTransformations` that apply to all elements of `datasets`. This is unneeded, because we can convey the exact same information via the `coordinateTransformations` field for each element of `datasets`. 
- `scale` and `translation` transformations are required for each element of `datasets`. Reasoning for this decision is added to the spec. 
- the `type` field of `multiscales` is removed. A better place for that information is inside the `metadata` field.
- the `version` field of `multiscales` is now required. If this is optional, it causes headaches for implementations / parsers, and the version should always be defined anyway, so we should mandate it.
- the types of some fields were made more explicit