### PR TITLE
improve description of omero metadata

### DIFF
--- a/0.4/index.bs
+++ b/0.4/index.bs
@@ -438,6 +438,12 @@ can be found under the "omero" key in the group-level metadata:
 See https://docs.openmicroscopy.org/omero/5.6.1/developers/Web/WebGateway.html#imgdata
 for more information.
 
+The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
+Each dictionary in "channels" MUST contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
+Each dictionary in "channels" MUST contain the field "window", which is a dictionary describing the windowing of the channel.
+The field "window" MUST contain the fields "min" and "max", which are the minimum and maximum values of the window, respectively. 
+It MUST also contain the fields "start" and "end", which are the start and end values of the window, respectively.
+
 "labels" metadata {#labels-md}
 ------------------------------
 

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -441,11 +441,6 @@ can be found under the "omero" key in the group-level metadata:
 See https://docs.openmicroscopy.org/omero/5.6.1/developers/Web/WebGateway.html#imgdata
 for more information.
 
-The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
-Each dictionary in "channels" MUST contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
-Each dictionary in "channels" MUST contain the field "window", which is a dictionary describing the windowing of the channel.
-The field "window" MUST contain the fields "min" and "max", which are the minimum and maximum values of the window, respectively. It MUST also contain the fields "start" and "end", which are the start and end values of the window, respectively.
-
 "labels" metadata {#labels-md}
 ------------------------------
 

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -441,6 +441,11 @@ can be found under the "omero" key in the group-level metadata:
 See https://docs.openmicroscopy.org/omero/5.6.1/developers/Web/WebGateway.html#imgdata
 for more information.
 
+The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
+Each dictionary in "channels" MUST contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
+Each dictionary in "channels" MUST contain the field "window", which is a dictionary describing the windowing of the channel.
+The field "window" MUST contain the fields "min" and "max", which are the minimum and maximum values of the window, respectively. It MUST also contain the fields "start" and "end", which are the start and end values of the window, respectively.
+
 "labels" metadata {#labels-md}
 ------------------------------
 


### PR DESCRIPTION
Currently, the omero metadata section in the specs could be a bit more descriptive, this is a small attempt.

This info was kindly summarized by @will-moore here: https://github.com/ome/ome-zarr-py/pull/261#issuecomment-1525658925

EDIT: while this PR is purely to improve documentation, might be related to potential relaxation of omero metadata as discussed in https://github.com/ome/ngff/issues/192