### PR TITLE
remove "windows" and "color" from omero metadata as required

### DIFF
--- a/latest/schemas/image.schema
+++ b/latest/schemas/image.schema
@@ -78,7 +78,7 @@
                   "start",
                   "min",
                   "end",
-                  "max"
+                  "max",
                 ]
               },
               "label": {
@@ -93,7 +93,7 @@
               "active": {
                 "type": "boolean"
               }
-            },
+            }
           }
         }
       },

--- a/latest/schemas/image.schema
+++ b/latest/schemas/image.schema
@@ -78,7 +78,7 @@
                   "start",
                   "min",
                   "end",
-                  "max",
+                  "max"
                 ]
               },
               "label": {

--- a/latest/schemas/image.schema
+++ b/latest/schemas/image.schema
@@ -94,10 +94,6 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "window",
-              "color"
-            ]
           }
         }
       },


### PR DESCRIPTION
ref #192 . I left the "windows" parameters as "required" but I'm not sure if it makes sense.
