### PR TITLE
Update citation to point to latest zenodo

### DIFF
--- a/0.4/index.bs
+++ b/0.4/index.bs
@@ -657,10 +657,10 @@ Citing {#citing}
 ================
 
 [Next-generation file format (NGFF) specifications for storing bioimaging data in the cloud.](https://ngff.openmicroscopy.org/0.4)
-J. Moore, *et al*. Editors. Open Microscopy Environment Consortium, 8 February 2022.
+J. Moore, *et al*. Editors. Open Microscopy Environment Consortium, 25 may 2023.
 This edition of the specification is [https://ngff.openmicroscopy.org/0.4/](https://ngff.openmicroscopy.org/0.4/]).
 The latest edition is available at [https://ngff.openmicroscopy.org/latest/](https://ngff.openmicroscopy.org/latest/).
-[(doi:10.5281/zenodo.4282107)](https://doi.org/10.5281/zenodo.4282107)
+[(doi:10.5281/zenodo.4282106)](https://doi.org/10.5281/zenodo.4282106)
 
 Version History {#history}
 ==========================

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -609,10 +609,10 @@ Citing {#citing}
 ================
 
 [Next-generation file format (NGFF) specifications for storing bioimaging data in the cloud.](https://ngff.openmicroscopy.org/0.4)
-J. Moore, *et al*. Editors. Open Microscopy Environment Consortium, 8 February 2022.
+J. Moore, *et al*. Editors. Open Microscopy Environment Consortium, 25 may 2023.
 This edition of the specification is [https://ngff.openmicroscopy.org/0.4/](https://ngff.openmicroscopy.org/0.4/]).
 The latest edition is available at [https://ngff.openmicroscopy.org/latest/](https://ngff.openmicroscopy.org/latest/).
-[(doi:10.5281/zenodo.4282107)](https://doi.org/10.5281/zenodo.4282107)
+[(doi:10.5281/zenodo.4282106)](https://doi.org/10.5281/zenodo.4282106)
 
 Version History {#history}
 ==========================


### PR DESCRIPTION
When going through the documentation I found that link to zenodo points to release 0.1 not the current one 0.4.1.

As you do not have `zenodod.json` and do not provide bibtext entry are you thinking that add one of these things could be a good idea (as bibtex generated by zenodo has different content to example citation string in the documentation)? 