### PR TITLE
Clarify `version` field

### DIFF
--- a/latest/index.bs
+++ b/latest/index.bs
@@ -326,10 +326,13 @@ Each "multiscales" dictionary MAY contain the field "coordinateTransformations",
 The transformations MUST follow the same rules about allowed types, order, etc. as in "datasets:coordinateTransformations" and are applied after them.
 They can for example be used to specify the `scale` for a dimension that is the same for all resolutions.
 
-Each "multiscales" dictionary SHOULD contain the field "name". It MUST contain the field "version", which indicates the version of the multiscale metadata of this image (current version is [NGFFVERSION]).
+Each "multiscales" dictionary SHOULD contain the field "name". 
+
+Each "multiscales" dictionary MUST contain the field "version", which is the string [NGFFVERSION].
 
 Each "multiscales" dictionary SHOULD contain the field "type", which gives the type of downscaling method used to generate the multiscale image pyramid.
-It SHOULD contain the field "metadata", which contains a dictionary with additional information about the downscaling method.
+
+Each "multiscales" dictionary SHOULD contain the field "metadata", which contains a dictionary with additional information about the downscaling method.
 
 <pre class=include-code>
 path: examples/multiscales_strict/multiscales_example.json
@@ -492,8 +495,7 @@ contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a 
 other `name` in the `rows` list. Care SHOULD be taken to avoid collisions on
 case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
 
-The `plate` dictionary MUST contain a `version` key whose value MUST be a string specifying the
-version of the plate specification.
+The `plate` dictionary MUST contain a `version` key whose value MUST be the string [NGFFVERSION].
 
 The `plate` dictionary MUST contain a `wells` key whose value MUST be a list of JSON objects
 defining the wells of the plate. Each well object MUST contain a `path` key whose value MUST
@@ -536,8 +538,7 @@ of any other `path` in the `images` list. If multiple acquisitions were performe
 it MUST contain an `acquisition` key whose value MUST be an integer identifying the acquisition
 which MUST match one of the acquisition JSON objects defined in the plate metadata (see #plate-md).
 
-The `well` dictionary SHOULD contain a `version` key whose value MUST be a string specifying the
-version of the well specification.
+The `well` dictionary SHOULD contain a `version` key whose value MUST the string [NGFFVERSION].
 
 For example the following JSON object defines a well with four fields of
 view. The first two fields of view were part of the first acquisition while

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -328,7 +328,7 @@ They can for example be used to specify the `scale` for a dimension that is the 
 
 Each "multiscales" dictionary SHOULD contain the field "name". 
 
-Each "multiscales" dictionary MUST contain the field "version", which is the string [NGFFVERSION].
+Each "multiscales" dictionary MUST contain the field "version", which is the string "[NGFFVERSION]".
 
 Each "multiscales" dictionary SHOULD contain the field "type", which gives the type of downscaling method used to generate the multiscale image pyramid.
 
@@ -495,7 +495,7 @@ contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a 
 other `name` in the `rows` list. Care SHOULD be taken to avoid collisions on
 case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
 
-The `plate` dictionary MUST contain a `version` key whose value MUST be the string [NGFFVERSION].
+The `plate` dictionary MUST contain a `version` key whose value MUST be the string "[NGFFVERSION]".
 
 The `plate` dictionary MUST contain a `wells` key whose value MUST be a list of JSON objects
 defining the wells of the plate. Each well object MUST contain a `path` key whose value MUST
@@ -538,7 +538,7 @@ of any other `path` in the `images` list. If multiple acquisitions were performe
 it MUST contain an `acquisition` key whose value MUST be an integer identifying the acquisition
 which MUST match one of the acquisition JSON objects defined in the plate metadata (see #plate-md).
 
-The `well` dictionary SHOULD contain a `version` key whose value MUST the string [NGFFVERSION].
+The `well` dictionary SHOULD contain a `version` key whose value MUST the string "[NGFFVERSION]".
 
 For example the following JSON object defines a well with four fields of
 view. The first two fields of view were part of the first acquisition while


### PR DESCRIPTION
For the various metadata objects with a `version` field, this PR makes explicit that `version` is a string, and that it must be the current version.