### PR TITLE
Update index.md to add stack_to_multiscale_ngff

### DIFF
--- a/tools/index.md
+++ b/tools/index.md
@@ -52,6 +52,9 @@ The [napari viewer](https://github.com/napari/napari) supports OME-Zarr with the
 ### NGFF-Converter
 <https://github.com/glencoesoftware/NGFF-Converter>
 
+### stack_to_multiscale_ngff
+<https://github.com/CBI-PITT/stack_to_multiscale_ngff>
+
 
 ## Libraries
 


### PR DESCRIPTION
Added pointer to stack_to_multiscale_ngff, a python package for high-performance conversion of image stacks to ome-ngff