### PR TITLE
Clarify use of `_ARRAY_DIMENSIONS` in v0.4 and latest

### DIFF
--- a/0.4/index.bs
+++ b/0.4/index.bs
@@ -145,7 +145,7 @@ For this example we assume an image with 5 dimensions and axes called `t,c,z,y,x
     ├── .zgroup               # Each image is a Zarr group, or a folder, of other groups and arrays.
     ├── .zattrs               # Group level attributes are stored in the .zattrs file and include
     │                         # "multiscales" and "omero" (see below). In addition, the group level attributes
-    │                         # must also contain "_ARRAY_DIMENSIONS" if this group directly contains multi-scale arrays.
+    │                         # may also contain "_ARRAY_DIMENSIONS" if this group directly contains multi-scale arrays.
     │
     ├── 0                     # Each multiscale level is stored as a separate Zarr array,
     │   ...                   # which is a folder containing chunk files which compose the array.

--- a/0.4/index.bs
+++ b/0.4/index.bs
@@ -145,7 +145,7 @@ For this example we assume an image with 5 dimensions and axes called `t,c,z,y,x
     ├── .zgroup               # Each image is a Zarr group, or a folder, of other groups and arrays.
     ├── .zattrs               # Group level attributes are stored in the .zattrs file and include
     │                         # "multiscales" and "omero" (see below). In addition, the group level attributes
-    │                         # may also contain "_ARRAY_DIMENSIONS" if this group directly contains multi-scale arrays.
+    │                         # may also contain "_ARRAY_DIMENSIONS" for compatibility with xarray if this group directly contains multi-scale arrays.
     │
     ├── 0                     # Each multiscale level is stored as a separate Zarr array,
     │   ...                   # which is a folder containing chunk files which compose the array.

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -93,7 +93,7 @@ For this example we assume an image with 5 dimensions and axes called `t,c,z,y,x
     ├── .zgroup               # Each image is a Zarr group, or a folder, of other groups and arrays.
     ├── .zattrs               # Group level attributes are stored in the .zattrs file and include
     │                         # "multiscales" and "omero" (see below). In addition, the group level attributes
-    │                         # may also contain "_ARRAY_DIMENSIONS" if this group directly contains multi-scale arrays.
+    │                         # may also contain "_ARRAY_DIMENSIONS" for compatibility with xarray if this group directly contains multi-scale arrays.
     │
     ├── 0                     # Each multiscale level is stored as a separate Zarr array,
     │   ...                   # which is a folder containing chunk files which compose the array.

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -93,7 +93,7 @@ For this example we assume an image with 5 dimensions and axes called `t,c,z,y,x
     ├── .zgroup               # Each image is a Zarr group, or a folder, of other groups and arrays.
     ├── .zattrs               # Group level attributes are stored in the .zattrs file and include
     │                         # "multiscales" and "omero" (see below). In addition, the group level attributes
-    │                         # must also contain "_ARRAY_DIMENSIONS" if this group directly contains multi-scale arrays.
+    │                         # may also contain "_ARRAY_DIMENSIONS" if this group directly contains multi-scale arrays.
     │
     ├── 0                     # Each multiscale level is stored as a separate Zarr array,
     │   ...                   # which is a folder containing chunk files which compose the array.


### PR DESCRIPTION
As of version 0.4 (and then including `latest` version), `_ARRAY_DIMENSIONS` is not a required attribute any more. This PR replaces the relevant "must" with a "may", and adds a clarification about the goal of this attribute (that is, it exists in view of xarray compatibility).

Closes #217