### PR TITLE
Add build.os to readthedocs.yml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 sphinx:
   configuration: conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 sphinx:
   configuration: conf.py


### PR DESCRIPTION
Fixes this build failure: https://readthedocs.org/projects/ngff/builds/22266168/
which refers to https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

(seen on https://github.com/ome/ngff/pull/218)

