### PR TITLE
Add community calendar

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -2,7 +2,12 @@
 
 ## Office Hours
 
+<!--
+Button styling for our theme needs work
 <button type="button" name="office-hours" class="btn" onclick="window.open('https://openmicroscopy-org.zoom.us/j/82526689042?pwd=ZIde7mcvZugQGmJ8Bm9piFo5Tzwdy1.1');">Join here</button>
+-->
+
+[**Join here!**](https://openmicroscopy-org.zoom.us/j/82526689042?pwd=ZIde7mcvZugQGmJ8Bm9piFo5Tzwdy1.1)
 
 <p><font size="4">We'll be hosting office hours on Wednesdays, rotating between
 APAC/AU/EU- and AMER/AU/EU-friendly times.

--- a/index.rst
+++ b/index.rst
@@ -18,6 +18,7 @@ Sample NGFF datasets provided by the community can be found under :doc:`data/ind
    :maxdepth: 2
 
    about/index
+   community/index
    data/index
    publications/index
    specifications/index


### PR DESCRIPTION
Primary purpose of the community calendar currently is to list the soon to-be-announced office hours, and we can build from there. @jwindhager is also proposing to use this subpage to collect several other items (in no particular order):

* team overview
* mission statement
* code of conduct
* governance
* contributors guide
* how to get engaged
