### PR TITLE
Add codespell to detect new typos and fix existing ones (even in prior versions since why not?)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/0.2/index.bs
+++ b/0.2/index.bs
@@ -236,7 +236,7 @@ It SHOULD contain the field "metadata", which contains a dictionary with additio
             ],
             "type": "gaussian",
             "metadata": {                                       # the fields in metadata depend on the downscaling implementation
-                "method": "skimage.transform.pyramid_gaussian", # here, the paramters passed to the skimage function are given
+                "method": "skimage.transform.pyramid_gaussian", # here, the parameters passed to the skimage function are given
                 "version": "0.16.1",
                 "args": "[true]",
                 "kwargs": {"multichannel": true}

--- a/0.3/index.bs
+++ b/0.3/index.bs
@@ -249,7 +249,7 @@ It SHOULD contain the field "metadata", which contains a dictionary with additio
             ],
             "type": "gaussian",
             "metadata": {                                       # the fields in metadata depend on the downscaling implementation
-                "method": "skimage.transform.pyramid_gaussian", # here, the paramters passed to the skimage function are given
+                "method": "skimage.transform.pyramid_gaussian", # here, the parameters passed to the skimage function are given
                 "version": "0.16.1",
                 "args": "[true]",
                 "kwargs": {"multichannel": true}

--- a/0.4/index.bs
+++ b/0.4/index.bs
@@ -107,7 +107,7 @@ be optional (MAY). Examples of transitional metadata include custom additions by
 implementations that are later submitted as a formal specification. (See [[#bf2raw]])
 </p>
 
-Some of the JSON examples in this document include commments. However, these are only for
+Some of the JSON examples in this document include comments. However, these are only for
 clarity purposes and comments MUST NOT be included in JSON objects.
 
 On-disk (or in-cloud) layout {#on-disk}
@@ -544,7 +544,7 @@ other `name` in the `rows` list. Care SHOULD be taken to avoid collisions on
 case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
 
 The `plate` dictionary SHOULD contain a `version` key whose value MUST be a string specifying the
-version of the plate specificaton.
+version of the plate specification.
 
 The `plate` dictionary MUST contain a `wells` key whose value MUST be a list of JSON objects
 defining the wells of the plate. Each well object MUST contain a `path` key whose value MUST
@@ -552,7 +552,7 @@ be a string specifying the path to the well subgroup. The `path` MUST consist of
 the `rows` list, a file separator (`/`), and a `name` from the `columns` list, in that order.
 The `path` MUST NOT contain additional leading or trailing directories.
 Each well object MUST contain both a `rowIndex` key whose value MUST be an integer identifying
-the index into the `rows` list and a `columnIndex` key whose value MUST be an integer indentifying
+the index into the `rows` list and a `columnIndex` key whose value MUST be an integer identifying
 the index into the `columns` list. `rowIndex` and `columnIndex` MUST be 0-based. The
 `rowIndex`, `columnIndex`, and `path` MUST all refer to the same row/column pair.
 

--- a/0.4/tests/test_validation.py
+++ b/0.4/tests/test_validation.py
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
     Generates tests for the examples/ as well as tests/ subdirectories.
 
     Examples:
-        These tests evalute all of the files under the examples/ directory
+        These tests evaluate all of the files under the examples/ directory
         using the configuration in the provided config file in order detect
         what should be run. It is assumed that all files are valid and complete
         so that they can be wholly included into the specification. The

--- a/latest/index.bs
+++ b/latest/index.bs
@@ -55,7 +55,7 @@ be optional (MAY). Examples of transitional metadata include custom additions by
 implementations that are later submitted as a formal specification. (See [[#bf2raw]])
 </p>
 
-Some of the JSON examples in this document include commments. However, these are only for
+Some of the JSON examples in this document include comments. However, these are only for
 clarity purposes and comments MUST NOT be included in JSON objects.
 
 On-disk (or in-cloud) layout {#on-disk}
@@ -501,7 +501,7 @@ be a string specifying the path to the well subgroup. The `path` MUST consist of
 the `rows` list, a file separator (`/`), and a `name` from the `columns` list, in that order.
 The `path` MUST NOT contain additional leading or trailing directories.
 Each well object MUST contain both a `rowIndex` key whose value MUST be an integer identifying
-the index into the `rows` list and a `columnIndex` key whose value MUST be an integer indentifying
+the index into the `rows` list and a `columnIndex` key whose value MUST be an integer identifying
 the index into the `columns` list. `rowIndex` and `columnIndex` MUST be 0-based. The
 `rowIndex`, `columnIndex`, and `path` MUST all refer to the same row/column pair.
 

--- a/latest/tests/test_validation.py
+++ b/latest/tests/test_validation.py
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
     Generates tests for the examples/ as well as tests/ subdirectories.
 
     Examples:
-        These tests evalute all of the files under the examples/ directory
+        These tests evaluate all of the files under the examples/ directory
         using the configuration in the provided config file in order detect
         what should be run. It is assumed that all files are valid and complete
         so that they can be wholly included into the specification. The


### PR DESCRIPTION
See https://github.com/codespell-project/codespell for more info about this handy tool