### PR TITLE
Update Fractal link & description

### DIFF
--- a/tools/index.md
+++ b/tools/index.md
@@ -135,9 +135,9 @@ An ITK external module for IO of images stored in Zarr-backed OME-NGFF file form
 ## Other tools and libraries
 
 ### Fractal
-<https://github.com/fractal-analytics-platform/fractal>
+<https://fractal-analytics-platform.github.io/>
 
-A framework to process high content screening data at scale and to prepare it for interactive visualization.
+A framework to process OME-Zarr data at scale with modular processing tasks and to prepare it for interactive visualization.
 
 
 ### Nyxus


### PR DESCRIPTION
I realized that the link for Fractal on the NGFF tools page was pointing to just the Fractal command line client. We now have a nice [Fractal splash page](https://fractal-analytics-platform.github.io/) that gives the overview of the framework. Would be great to update the link to that => see this PR :)

I also made some minor changes to the Fractal description to better reflect the current scope.