### PR TITLE
Add bia ngff link to data page

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -10,6 +10,7 @@ Data Resources
 | [JAX](https://images.jax.org/webclient/userdata/?experimenter=-1) | The Jackson Laboratory          |   17000       | 192 TB   |
 | [Glencoe](https://glencoesoftware.com/ngff)                              | Glencoe Software, Inc.                               | 8            | 165 GB   |
 | [IDR Samples](https://idr.github.io/ome-ngff-samples/)                   | EBI                                                  | 88           | 3 TB     |
+| [IDR Studies](https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/pages/idr_ngff_data.html) | EBI                               | 1644         | 47 TB    |
 | [MoBIE](https://mobie.github.io/specs/ngff.html)                         | EMBL-HD                                              | 21           | 2 TB     |
 | [Neural Dynamics](https://registry.opendata.aws/allen-nd-open-data/)     | AWS Open Data Program                                | 90           | 200 TB   |
 | [Sanger](https://www.sanger.ac.uk/project/ome-zarr/)                     | Sanger, UK                                           | 10           | 1 TB     |


### PR DESCRIPTION
Add link https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/pages/idr_ngff_data.html to data page.
NB data size is approx estimate from totals listed on studies.txt page before conversion to NGFF.

NB: I wonder if we want to add a note somewhere that opening Plates in vizarr often doesn't work because of the trailing `/0` as it's expecting `bioformats2raw` format.
E.g https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/pages/S-BIAD847/02fb729e-803a-4c2e-b40c-cf58d839567c.html shows nothing, and when you open in vizarr you get:
https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD847/02fb729e-803a-4c2e-b40c-cf58d839567c/02fb729e-803a-4c2e-b40c-cf58d839567c.zarr/0 which looks broken.
You need to remove the trailing `/0` before it's viewable:


