### PR TITLE
Clarify that axes MUST be a list of dictionaries

### DIFF
--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -179,7 +179,7 @@ The OME-Zarr Metadata version MUST be consistent within a hierarchy.
 "axes" metadata {#axes-md}
 --------------------------
 
-"axes" describes the dimensions of a physical coordinate space. It is a list of dictionaries, where each dictionary describes a dimension (axis) and:
+"axes" describes the dimensions of a physical coordinate space. It MUST be list of dictionaries, where each dictionary describes a dimension (axis) and:
 - MUST contain the field "name" that gives the name for this dimension. The values MUST be unique across all "name" fields.
 - SHOULD contain the field "type". It SHOULD be one of "space", "time" or "channel", but MAY take other string values for custom axis types that are not part of this specification yet.
 - SHOULD contain the field "unit" to specify the physical unit of this dimension. The value SHOULD be one of the following strings, which are valid units according to UDUNITS-2.


### PR DESCRIPTION
I think the intent with "It is a list of dicionaries" was a tight constraint, so I've replaced it with "MUST".