### PR TITLE
rm schema_url from spec

### DIFF
--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -404,7 +404,6 @@ labeled multiscale image(s). All label images SHOULD be listed within this metad
   "attributes": {
     "ome": {
       "version": "0.5",
-      "schema_url": "https://ngff.openmicroscopy.org/latest/schemas/ome_zarr.schema",
       "labels": [
         "cell_space_segmentation"
       ]


### PR DESCRIPTION
Removes a reference to `schema_url` from the 0.5 spec doc.