### PR TITLE
0.5.1: replace the missing omero metadata text (fix #286)

### DIFF
--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -381,6 +381,12 @@ can be found under the "omero" key in the group-level metadata:
 See the [OMERO WebGateway documentation](https://omero.readthedocs.io/en/stable/developers/Web/WebGateway.html#imgdata)
 for more information.
 
+The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
+Each dictionary in "channels" MUST contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
+Each dictionary in "channels" MUST contain the field "window", which is a dictionary describing the windowing of the channel.
+The field "window" MUST contain the fields "min" and "max", which are the minimum and maximum values of the window, respectively.
+It MUST also contain the fields "start" and "end", which are the start and end values of the window, respectively.
+
 "labels" metadata {#labels-md}
 ------------------------------
 
@@ -589,6 +595,11 @@ Version History {#history}
       <td>Description</td>
     </tr>
   </thead>
+  <tr>
+    <td>0.5.1</td>
+    <td>2025-01-10</td>
+    <td>Re-add the improved omero description in PR-191.</td>
+  </tr>
   <tr>
     <td>0.5</td>
     <td>2024-11-21</td>

--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -601,7 +601,7 @@ Version History {#history}
     <td>Re-add the improved omero description in PR-191.</td>
   </tr>
   <tr>
-    <td>0.5</td>
+    <td>0.5.0</td>
     <td>2024-11-21</td>
     <td>use Zarr v3 in OME-Zarr, see <a href="https://ngff.openmicroscopy.org/rfc/2">RFC-2</a>.</td>
   </tr>


### PR DESCRIPTION
The block of text explaining the requirements of the
"omero" metadata block added in #191 was only applied
to the 0.4/index.bs file and not to latest/index.bs
such that on publication the 0.5/index.bs also did not
have the change.

This restores that text as 0.5.1 with no change to the
on-disk format.
