### PR TITLE
Clarifies that `dimension_names` remains an optional attribute

### DIFF
--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -188,7 +188,7 @@ The OME-Zarr Metadata version MUST be consistent within a hierarchy.
 
 The "axes" are used as part of [[#multiscale-md]]. The length of "axes" MUST be equal to the number of dimensions of the arrays that contain the image data.
 
-The "dimension_names" attribute in the `zarr.json` of the Zarr array of a multiscale level MUST match the names in the "axes" metadata.
+The "dimension_names" attribute in the `zarr.json` of the Zarr array of a multiscale level, if defined, MUST match the names in the "axes" metadata.
 
 
 "bioformats2raw.layout" (transitional) {#bf2raw}


### PR DESCRIPTION
fixes https://github.com/ome/ngff/issues/289

(also fixes co-author issue)