### PR TITLE
Omero metadata optional

### DIFF
--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -382,10 +382,14 @@ See the [OMERO WebGateway documentation](https://omero.readthedocs.io/en/stable/
 for more information.
 
 The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
+The "channels" array length SHOULD correspond to the size of the "c" axis.
 Each dictionary in "channels" MAY contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
+Each dictionary in "channels" MAY contain the field "label", which is a string and a boolean "active" field to indicate whether the channel
+should be displayed.
 Each dictionary in "channels" MAY contain the field "window", which is a dictionary describing the windowing of the channel.
 The field "window" MAY contain the fields "min" and "max", which should correspond to the minimum and maximum pixel intensities for that channel, respectively.
 It MAY also contain the fields "start" and "end", which are the suggested start and end rendering settings of the window, respectively.
+Each dictionary in "channels" MAY contain the boolean field "inverted". If true, the renderinging of darkest to brightest pixels should be inverted.
 
 "labels" metadata {#labels-md}
 ------------------------------

--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -383,13 +383,19 @@ for more information.
 
 The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
 The "channels" array length SHOULD correspond to the size of the "c" axis.
-Each dictionary in "channels" MAY contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
-Each dictionary in "channels" MAY contain the field "label", which is a string and a boolean "active" field to indicate whether the channel
-should be displayed.
-Each dictionary in "channels" MAY contain the field "window", which is a dictionary describing the windowing of the channel.
-The field "window" MAY contain the fields "min" and "max", which should correspond to the minimum and maximum pixel intensities for that channel, respectively.
-It MAY also contain the fields "start" and "end", which are the suggested start and end rendering settings of the window, respectively.
-Each dictionary in "channels" MAY contain the boolean field "inverted". If true, the renderinging of darkest to brightest pixels should be inverted.
+Each dictionary in "channels" MAY contain the following fields:
+
+- "color" (string) String of 6 hexadecimal digits specifying the color of the channel in RGB format.
+- "label" (string) Channel name.
+- "active" (boolean) Indicates whether the channel should be displayed.
+- "window" (dictionary) Values describing the windowing of the channel. All values are optional (MAY).
+  The "min" and "max" values may be used by viewers as the range of channel sliders.
+  All values can be floating-point numbers, but will likely be integers for integer pixel types.
+  - "min" (float) Should correspond to the minimum pixel intensity for that channel.
+  - "max" (float) Should correspond to the maximum pixel intensity for that channel.
+  - "start" (float) Start of the rendering window.
+  - "end" (float) End of the rendering window.
+- "inverted" (boolean) If true, the rendering of darkest to brightest pixels should be inverted.
 
 "labels" metadata {#labels-md}
 ------------------------------

--- a/0.5/index.bs
+++ b/0.5/index.bs
@@ -382,10 +382,10 @@ See the [OMERO WebGateway documentation](https://omero.readthedocs.io/en/stable/
 for more information.
 
 The "omero" metadata is optional, but if present it MUST contain the field "channels", which is an array of dictionaries describing the channels of the image.
-Each dictionary in "channels" MUST contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
-Each dictionary in "channels" MUST contain the field "window", which is a dictionary describing the windowing of the channel.
-The field "window" MUST contain the fields "min" and "max", which are the minimum and maximum values of the window, respectively.
-It MUST also contain the fields "start" and "end", which are the start and end values of the window, respectively.
+Each dictionary in "channels" MAY contain the field "color", which is a string of 6 hexadecimal digits specifying the color of the channel in RGB format.
+Each dictionary in "channels" MAY contain the field "window", which is a dictionary describing the windowing of the channel.
+The field "window" MAY contain the fields "min" and "max", which should correspond to the minimum and maximum pixel intensities for that channel, respectively.
+It MAY also contain the fields "start" and "end", which are the suggested start and end rendering settings of the window, respectively.
 
 "labels" metadata {#labels-md}
 ------------------------------


### PR DESCRIPTION
NB: This shouldn't be merged into 0.5, and should wait until https://github.com/ome/ngff/issues/276 is resolved.

Fixes #192.

The `omero` metadata is useful for storing channels names (labels), colors and rendering settings, but currently ALL fields are required which means it is hard to use if any of these values are unknown.

This PR proposes that all the omero.channels values are optional.
It also adds more details for "label", "active" and "inverted" as well as notes on the "window" values.

cc @giovp @dstansby