### PR TITLE
Use s prefix for multiscale example

### DIFF
--- a/examples/multiscales_strict/multiscales_example.json
+++ b/examples/multiscales_strict/multiscales_example.json
@@ -16,7 +16,7 @@
           ],
           "datasets": [
             {
-              "path": "0",
+              "path": "s0",
               "coordinateTransformations": [
                 {
                   // the voxel size for the first scale level (0.5 micrometer)
@@ -26,7 +26,7 @@
               ]
             },
             {
-              "path": "1",
+              "path": "s1",
               "coordinateTransformations": [
                 {
                   // the voxel size for the second scale level (downscaled by a factor of 2 -> 1 micrometer)
@@ -36,7 +36,7 @@
               ]
             },
             {
-              "path": "2",
+              "path": "s2",
               "coordinateTransformations": [
                 {
                   // the voxel size for the third scale level (downscaled by a factor of 4 -> 2 micrometer)


### PR DESCRIPTION
There is a tendency to replicate the examples exactly. Having multiscale paths only being a number can be easily confused with chunk paths. Overall, the examples are being interpreted as recommended conventions so we may want to consider the implications of the names used in the examples.

This is a minor change since it just modifies the example without modification to the actual schemas. Having a path that is just a number remains valid. This would also match the existing n5 convention:

https://github.com/saalfeldlab/n5-viewer?tab=readme-ov-file#n5-viewer-metadata