### PR TITLE
Enable MyST strikethrough extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,7 +16,7 @@ author = "NGFF Community"
 extensions = ["myst_parser"]
 source_suffix = [".rst", ".md"]
 myst_heading_anchors = 5
-myst_enable_extensions = ["deflist"]
+myst_enable_extensions = ["deflist", "strikethrough"]
 
 templates_path = ["_templates"]
 exclude_patterns = [


### PR DESCRIPTION
Enable [MyST's strikethrough extension](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#strikethrough) to allow for `~~` delimiters 