### PR TITLE
sync spec text with json examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -47,20 +47,6 @@ implementations that are later submitted as a formal specification. (See [[#bf2r
 Some of the JSON examples in this document include comments. However, these are only for
 clarity purposes and comments MUST NOT be included in JSON objects.
 
-Extra keys in JSON objects
---------------------------
-
-Unless otherwise stated, a JSON object defined in this document MAY contain additional keys
-beyond those enumerated in its definition. The presence of an additional key in such a JSON
-object MUST NOT be treated as an error by implementations.
-
-Whether an implementation ignores the extra keys or propagates them is up to that particular
-implementation. It is recommended that implementations clearly declare how they handle extra
-keys, with a particular emphasis on informing users in the context of irreversible operations.
-For example, an implementation that resaves OME-Zarr data and ignores extra keys could implement
-a routine that warns users when they attempt to resave OME-Zarr data with extra keys.
-
-
 Storage format {#storage-format}
 ================================
 


### PR DESCRIPTION
Dear all,

This PR is intended as a fix for #322 and #309. Some confusion was raised in these issues as to whether different `version` keys would be allowed in an ome-zarrs top-level `zarr.json` and in a following `plate`/`well`/`labels` groups therein. 

In the current examples on the 0.5 branch (e.g., [plate example](https://github.com/ome/ngff/blob/8cbba216e37407bd2d4bd5c7128ab13bd0a6404e/examples/plate_strict/plate_2wells.json)), the `version key` is only given at the top level and not in the group-level. This is in contradiction to the current text of the [plate spec](https://ngff.openmicroscopy.org/0.5/index.html#plate-md), which states:

> The plate dictionary MUST contain a version key whose value MUST be a string specifying the version of the plate specification.

Same for [wells ](https://github.com/ome/ngff/blob/8cbba216e37407bd2d4bd5c7128ab13bd0a6404e/examples/well_strict/well_2fields.json) and [labels ](https://github.com/ome/ngff/blob/8cbba216e37407bd2d4bd5c7128ab13bd0a6404e/examples/label_strict/colors_properties.json) groups examples.

## Context and consequences

For context, the `version` key was originally moved up into the top-level `ome` group under the pretext of discouraging different metadata versions inside the same file according to RFC2:

> While technically possible, OME-Zarr 0.5 (with Zarr v3) and OME-Zarr 0.4 (with Zarr v2) metadata could exist side-by-side in a Zarr hierarchy, it is NOT RECOMMENDED. This may be useful for short periods of time (i.e. during migrations from 0.4 to 0.5), but should not be used longer term. Multiple metadata versions can lead to conflicts, which may be hard to resolve by implementations. If implementations encounter 0.4 and 0.5 metadata side-by-side, 0.5 SHOULD be treated preferentially.

Removing the statements about the `version` keys in the plate/well/labels groups essentially drops the idea differing versions inside a single ome.zarr file, which I think is a reasonable step from an implementation perspective. Also, it brings the spec back into sync with the examples, which I think is important for the integrity of this project.

I modified the statement at the top-level `ome` group into the following to make this clear:

> The OME-Zarr Metadata is stored in the various `zarr.json` files throughout the above array
hierarchy. The OME-Zarr Metadata version MUST be consistent within a hierarchy. The top-level `ome`
group MUST contain a `version` key whose value MUST be a string specifying the version of the
metadata specification.


Let me know what you think :)

cc @joshmoore @normanrz @dstansby @ziw-liu 

PS: Hope I got this PR configured right - had a bit of trouble getting the knack about contributing with submodules (#323)