### PR TITLE
Add CryoET Data Portal entry

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -4,6 +4,7 @@ Data Resources
 | Catalog                                                                  | Hosting                                              | Zarr Files   | Size     |
 | ------------------------------------------------------------------------ | -----------------------------------------------------| ------------ | -------- |
 | [BIA Samples](https://bit.ly/bia-ome-ngff-samples)                       | EBI                                                  | 90           | 200 GB   |
+| [CryoET Data Portal](https://cryoetdataportal.czscience.com))            | AWS Open Data Program                                | 37585        | 70 TB    |
 | [Cell Painting Gallery](https://github.com/broadinstitute/cellpainting-gallery) | AWS Open Data Program                         | 136          | 20 TB    |
 | [CZB-Zebrahub](https://zebrahub.ds.czbiohub.org/imaging)                 | czbiohub                                             | 5            | 1.2 TB   |
 | [DANDI](https://dandiarchive.org/dandiset/000108) ([identifiers.org][dandi2],[github][dandi3]) | AWS Open Data Program          | 3914         | 355 TB   |


### PR DESCRIPTION
The CryoET Data Portal has many Zarr v2 datasets, and includes Zarr in their pipeline. 

Overview of the data at this sandbox:

http://tiago.bio.br/ome2024-ngff-challenge/?csv=https://raw.githubusercontent.com/lubianat/ome2024-ngff-challenge/refs/heads/sandbox/samples/cryoet_manifest.csv

I have added a discussion at the CryoET GitHub forum about v3, as they seem quite active: https://github.com/chanzuckerberg/cryoet-data-portal/discussions/1966 