### PR TITLE
Ignore zar

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@
 skip = .git,.codespellrc
 check-hidden = true
 # ignore-regex = 
-ignore-words-list = commend,Fuchsia
+ignore-words-list = commend,Fuchsia,zar


### PR DESCRIPTION
Ignore `zar` spelling leading to error