### PR TITLE
fix version semantics for 0.6.dev2

### DIFF
--- a/rfc/5/index.md
+++ b/rfc/5/index.md
@@ -33,7 +33,7 @@ This RFC is currently in RFC state `R4` (authors prepare responses).
 
 This RFC provides first-class support for spatial and coordinate transformations in OME-Zarr.
 
-Working version title: **0.6dev2**
+Working version title: **0.6.dev2**
 
 ## Background
 

--- a/rfc/5/responses/1/index.md
+++ b/rfc/5/responses/1/index.md
@@ -166,7 +166,7 @@ The `multiscales` metadata contains this:
 {
     "multiscales": [
         {
-            "version": "0.6dev2",
+            "version": "0.6.dev2",
             "name": "example",
             "coordinateSystems": [
                 {


### PR DESCRIPTION
In the previously submitted [proposal of RFC5](https://ngff.openmicroscopy.org/rfc/5/index.html#overview), the associated version was named `0.6dev2` in contrast to the previously used `0.6.dev2`. This led to problems elsewhere, so this is reverting it back. It has also been changed accordingly in these PRs:

- https://github.com/ome/ngff-spec/pull/17
- https://github.com/jo-mueller/ngff-rfc5-coordinate-transformation-examples/pull/14

This should make the versioning semantic consistent across all relevant places. The ome ngff validator has already been made robust to such changes [here](https://github.com/ome/ome-ngff-validator/commit/b4ee3bb395407fb9c9255d5729db3c08e75d1f3e)

*Edit*: typos