### PR TITLE
RFC 3: Make removal of restriction on axis ordering more explicit

### DIFF
--- a/rfc/3/index.md
+++ b/rfc/3/index.md
@@ -131,7 +131,7 @@ illumination directions, or views respectively. To say nothing of synthetic data
 that may contain "artificial" dimensions such as principal components or axes of
 other dimensionality reduction-techniques from many images. They may also hamper
 the adoption of OME-Zarr as an acquisition-time format due to performance concerns
-when data must be manipulated to accomodate a strict dimension order.
+when data must be manipulated to accommodate a strict dimension order.
 
 ## Motivation
 


### PR DESCRIPTION
This slight re-wording, and small addition, makes it more explicit that this RFC intends to remove the strict TCZYX ordering requirement. (it's already in there, but I want to make sure there's no room for misinterpretation). It also adds two small notes of rationale, explicitly mentioning that we'd like to be able to use OME-Zarr as an acquisition-time format without incurring possibly costly transpositions in a performance critical runtime.

@jni, please let me know if you have any concerns, or requests for rewording or removals.