### PR TITLE
reactivate review action

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,27 +1,25 @@
-# ---
-# name: Add review url
+---
+name: Add review url
 
-# on:
-#   pull_request_target:
+on:
+  pull_request_target:
 
-# jobs:
-#   build:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: peter-evans/find-comment@v2
-#         id: fc
-#         with:
-#           issue-number: ${{ github.event.pull_request.number }}
-#           comment-author: 'github-actions[bot]'
-#           body-includes: Automated Review URLs
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Automated Review URLs
 
-#       - uses: peter-evans/create-or-update-comment@v2
-#         with:
-#           comment-id: ${{ steps.fc.outputs.comment-id }}
-#           issue-number: ${{ github.event.pull_request.number }}
-#           body: |
-#             #### Automated Review URLs
-#             * [Readthedocs](https://ngff--${{ github.event.pull_request.number }}.org.readthedocs.build/)
-#             * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/ome/ngff/${{ github.event.pull_request.head.sha }}/latest/index.bs)
-#             * [diff latest modified](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fngff.openmicroscopy.org%2Flatest%2F&doc2=http%3A%2F%2Fapi.csswg.org%2Fbikeshed%2F%3Furl%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fome%2Fngff%2F${{  github.event.pull_request.head.sha }}%2Flatest%2Findex.bs)
-#           edit-mode: replace
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            #### Automated Review URLs
+            * [Readthedocs](https://ngff--${{ github.event.pull_request.number }}.org.readthedocs.build/)
+          edit-mode: replace


### PR DESCRIPTION
Follow-up to #404

I just realized that I had uncommented the entirety of the review gh action in #404 while working on the PR, as it contained quite a few bs stuff - and forgot to re-activate it. The preview build is still there if one clicks on the readthedocs action at the bottom of the thread, but the comment in the conversation isn't.

This PR removes the bs build from the preview action and re-enables the gh previews. Relevant for #439!