### PR TITLE
Improved .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,7 +13,6 @@ Lila Schweinfurth <lila.schweinfurth@gmail.com>
 Mark Kittisopikul <kittisopikulm@janelia.hhmi.org> <markkitt@gmail.com>
 Mark Kittisopikul <kittisopikulm@janelia.hhmi.org> <mkitti@users.noreply.github.com>
 Matt McCormick <matt@fideus.io> <matt@mmmccormick.com>
-Matt McCormick <matt@fideus.io> <matt@mmmccormick.com>
 Matt McCormick <matt@fideus.io> <matt.mccormick@kitware.com>
 Sébastien Besson <seb.besson@gmail.com>
 Tiago Lubiana <tiago.lubiana@gerbi-gmb.de> <tiagolubiana@gmail.com>


### PR DESCRIPTION
Inspired by https://github.com/ome/ngff/issues/442, this adds an improved .mailmap file to normalise email addresses and names used by `git`. Where multiple emails are available in the log, I've chosen the most used or the non-GitHub one.

cc @bugraoezdemir, @cfusterbarcelo, @clbarnes, @constantinpape, @giovp, @bogovicj, @jwindhager, @joshmoore, @kbab, @mkitti, @thewtex, @lubianat, @vuhlmann as folks I've updated here - let me know if you have a different preferred email or name.