### PR TITLE
fix: update Dependabot path for gitsubmodule (#452)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gitsubmodule"
-    directory: "/specifications/dev"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Related to #449, fixes #452

This assumes that we want Dependabot to track all submodules (not only dev, but also previous versions). 

It will look into `.gitmodules` for the updates (which is in `/`, and not in `/specifications/dev`).

My experience with Dependabot is limited, though, so I might be overlooking something. 
