### PR TITLE
Fix Maitin-Shepard's name

### DIFF
--- a/rfc/5/comments/2/index.md
+++ b/rfc/5/comments/2/index.md
@@ -2,7 +2,7 @@
 
 ## Comment author
 
-Jeremy Maitin-Shephard
+Jeremy Maitin-Shepard
 
 ## Minor comments and questions
 


### PR DESCRIPTION
Related to: 

- #467 

Typo identified after (and because of) #450 

source e.g. https://research.google/people/jeremymaitinshepard/ 