### PR TITLE
docs: enable pdf and epub export

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,6 +10,10 @@ submodules:
   include: all
   recursive: true
 
+formats:
+  - epub
+  - pdf
+
 sphinx:
   configuration: conf.py
 


### PR DESCRIPTION
Fixes #475 

This PR enables the pdf/epub export for all documents on the ngff pages