### PR TITLE
docs: add version history to spec page build

### DIFF
--- a/rfc/5/index.md
+++ b/rfc/5/index.md
@@ -14,7 +14,7 @@ Add named coordinate systems and expand and clarify coordinate transformations. 
 
 ## Status
 
-This RFC is currently in RFC state `R4` (authors prepare responses).
+This RFC is currently in RFC state `S4` (Update implementations).
 
 | **Role** | Name | GitHub Handle | Institution | Date | Status |
 |----------|------|---------------|-------------|------|--------|
@@ -37,7 +37,7 @@ This RFC is currently in RFC state `R4` (authors prepare responses).
 
 This RFC provides first-class support for spatial and coordinate transformations in OME-Zarr.
 
-Working version title: **0.6.dev3**
+Version associated with this document: **0.6.dev3**
 
 ## Background
 

--- a/rfc/5/index.md
+++ b/rfc/5/index.md
@@ -1156,6 +1156,16 @@ choose between different options, or software could choose a default (e.g. the f
 
 ## Changelog
 
-| Date       | Description                  | Link                                                                         |
-| ---------- | ---------------------------- | ---------------------------------------------------------------------------- |
-| 2024-10-08 | RFC assigned and published   | [https://github.com/ome/ngff/pull/255](https://github.com/ome/ngff/pull/255) |
+| Date       | Description                  | Link|
+| -  | -| - |
+| 2024-10-08 | RFC assigned and published | [https://github.com/ome/ngff/pull/255](https://github.com/ome/ngff/pull/255) |
+| 2025-07-01 | First reviews | [Review 1](./reviews/1/index.md), [Review 2](./reviews/2/index.md) |
+| 2025-11-26 | First specification draft published | [https://github.com/ome/ngff-spec/releases/tag/0.6.dev1](https://github.com/ome/ngff-spec/releases/tag/0.6.dev1) |
+| 2025-08-01 | [Revised version submitted and published](./versions/2/index.md) | [https://github.com/ome/ngff/pull/350](https://github.com/ome/ngff/pull/350) |
+| 2025-12-02 | Revised specification published (0.6.dev2) | [https://github.com/ome/ngff-spec/releases/tag/0.6.dev2](https://github.com/ome/ngff-spec/releases/tag/0.6.dev2) |
+| 2025-12-01 | Second reviews, RFC accepted with minor revisions | [Review 1](./reviews/1b/index.md), [Review 2](./reviews/2b/index.md) |
+| 2026-01-16 | RFC revised and published | [https://github.com/ome/ngff/pull/389](https://github.com/ome/ngff/pull/389) |
+| 2026-03-13 | Revised specification published (0.6.dev3) | [https://github.com/ome/ngff-spec/releases/tag/0.6.dev3](https://github.com/ome/ngff-spec/releases/tag/0.6.dev3) |
+| 2026-04-28 | Revised specification published (0.6.dev4) | [https://github.com/ome/ngff-spec/releases/tag/0.6.dev4](https://github.com/ome/ngff-spec/releases/tag/0.6.dev4) |
+
+[Detailed summary of changes](../../specifications/dev/version_history.md)

--- a/specifications/index.md
+++ b/specifications/index.md
@@ -16,4 +16,5 @@ dev/index.md
 0.2/index.md
 0.1/index.md
 
+dev/version_history
 ```


### PR DESCRIPTION
Fixes https://github.com/ome/ngff/issues/515

This adds the version history file from the ngff-spec page to the ngff page and updates the version history on the rfc5 page. I hope it also clarifies that the last version associated with rfc5 is 0.6.dev3, after which came some smaller changes. Those are not represented by an RFC, but still listed in the version history in more detail.