### PR TITLE
RFC-4: Clarify subject-local orientation and add layered-tissue vocabulary

### DIFF
--- a/rfc/4/index.md
+++ b/rfc/4/index.md
@@ -97,6 +97,8 @@ This distinction matters for fields such as spatial transcriptomics and histopat
 
 Supporting subject-local orientation makes this metadata applicable to the tissue-profiling community without requiring registration of the specimen to a whole-organism or atlas coordinate system. When such a registration is available, it can be expressed with RFC-5 coordinate transformations relating the subject-local axes to a patient-global or atlas coordinate system (see the *Interaction with RFC-5* section below).
 
+A single subject may carry more than one meaningful orientation. For example, a biopsy taken from a whole-body cleared specimen has both a local tissue orientation and a secondary orientation within the donor's whole body. The `orientation` field defined here describes a single, *primary* orientation of the structure in the image. Additional (secondary) orientations are not supported at this time. If a generic vector data structure is added to the OME-Zarr standard in the future, these orientation annotations could be applied to such vectors, allowing multiple orientations to be expressed where anatomical orientation only makes sense locally (for example, an image containing multiple organs or multiple organisms).
+
 ### Coordinate Direction Convention
 
 The directional orientation values (e.g., "anterior-to-posterior", "left-to-right") specify the direction from lowest to highest coordinates along the axis. For example, an axis with `"orientation": {"type": "anatomical", "value": "anterior-to-posterior"}` indicates that:
@@ -482,6 +484,7 @@ enum AnatomicalOrientationValue {
 - **Costs:** This will add another field to the axes metadata. While some implementers do not deal with anatomical orientation, this field is optional.
 - **Risks:** Incorrect implementation or interpretation of the new field could lead to data misalignment.
 - **Alternatives:** Continue using existing methods with assumed or undefined orientations, which is error-prone.
+- **Primary vs. secondary orientation:** Modeling a subject as carrying both a primary (subject-local) and a secondary (e.g. patient-global) orientation simultaneously was considered. A single subject can have more than one meaningful orientation — for example, a biopsy taken from a whole-body cleared specimen has a local tissue orientation as well as a secondary orientation within the donor's whole body. Supporting multiple orientations per axis was judged to be overkill for the current emerging use cases, so the `orientation` field describes only a single, primary orientation and additional orientations are not supported at this time. If a generic vector data structure is added to the OME-Zarr standard in the future, these orientation annotations could instead be applied to such vectors, allowing multiple orientations to be expressed where anatomical orientation only makes sense locally (for example, an image containing multiple organs or multiple organisms).
 
 ## Abandoned Ideas
 
@@ -562,3 +565,4 @@ End-user applications SHOULD display the encoded information with, for example, 
 | 2026-01-20 | Clarify coordinate direction convention | [https://github.com/ome/ngff/pull/428](https://github.com/ome/ngff/pull/428) |
 | 2026-06-03 | Clarify subject-local vs. patient-global orientation and expand the controlled vocabulary with layered- and polarized-tissue terms (superficial/deep, apical/basal, apex/base), per [review 3](./reviews/3/index). | [https://github.com/ome/ngff/pull/435](https://github.com/ome/ngff/pull/435) |
 | 2026-06-04 | Clarify that an absent `orientation` and an explicit `null` `orientation` are equivalent and leave the orientation undefined. | [https://github.com/fideus-labs/ngff-zarr/pull/523](https://github.com/fideus-labs/ngff-zarr/pull/523) |
+| 2026-06-12 | Clarify that `orientation` describes a single, primary orientation; note that secondary orientations are not supported and could be expressed via a future generic vector data structure, and record the primary-vs-secondary alternative considered. | [https://github.com/ome/ngff/pull/528](https://github.com/ome/ngff/pull/528) |

--- a/rfc/4/index.md
+++ b/rfc/4/index.md
@@ -89,7 +89,7 @@ This metadata MUST only be used in cases where there is a single subject in the 
 
 The `orientation` field is structured as an object and MUST have a `type` field that specifies the orientation domain (e.g., "anatomical") and MUST have a `value` field that specifies the specific orientation within that domain. Valid `type` strings are defined in this document -- currently only `"anatomical"`.
 
-### Subject-Local vs. Patient-Global Orientation
+### Subject-Local vs. Subject-Global Orientation
 
 The "subject" referenced above need not be a whole organism. It MAY be a local anatomical structure, such as a tissue biopsy, histology slide, or dissected organ. The `orientation` field describes the orientation of whatever structure is present in the acquired image or extracted region-of-interest, at whatever spatial scale.
 

--- a/rfc/4/index.md
+++ b/rfc/4/index.md
@@ -89,6 +89,14 @@ This metadata MUST only be used in cases where there is a single subject in the 
 
 The `orientation` field is structured as an object and MUST have a `type` field that specifies the orientation domain (e.g., "anatomical") and MUST have a `value` field that specifies the specific orientation within that domain. Valid `type` strings are defined in this document -- currently only `"anatomical"`.
 
+### Subject-Local vs. Patient-Global Orientation
+
+The "subject" referenced above need not be a whole organism. It MAY be a local anatomical structure, such as a tissue biopsy, histology slide, or dissected organ. The `orientation` field describes the orientation of whatever structure is present in the acquired image or extracted region-of-interest, at whatever spatial scale.
+
+This distinction matters for fields such as spatial transcriptomics and histopathology, where the sample is frequently a tissue specimen whose position and orientation relative to the whole donor (its "patient-global" orientation) is unknown, but whose internal ("subject-local") orientation is well defined. For example, the depth axis of a skin biopsy is `superficial-to-deep` regardless of where on the body the biopsy was taken or how the specimen happened to be placed on the slide. In these cases the requirement that the subject be "roughly aligned to the imaging axes" applies to the local tissue structure rather than to a whole-organism coordinate frame.
+
+Supporting subject-local orientation makes this metadata applicable to the tissue-profiling community without requiring registration of the specimen to a whole-organism or atlas coordinate system. When such a registration is available, it can be expressed with RFC-5 coordinate transformations relating the subject-local axes to a patient-global or atlas coordinate system (see the *Interaction with RFC-5* section below).
+
 ### Coordinate Direction Convention
 
 The directional orientation values (e.g., "anterior-to-posterior", "left-to-right") specify the direction from lowest to highest coordinates along the axis. For example, an axis with `"orientation": {"type": "anatomical", "value": "anterior-to-posterior"}` indicates that:
@@ -135,7 +143,6 @@ This RFC focuses on anatomical orientation as the primary use case, but the stru
 - engineering/microfluidics: upstream/downstream (flow direction)
 - geographical: north/south, east/west
 - oceanographic: increasing-depth
-- histological: basal/apical
 
 For anatomical orientation, the controlled vocabulary for the `orientation` field's `value` will include:
 
@@ -162,6 +169,14 @@ For anatomical orientation, the controlled vocabulary for the `orientation` fiel
 - `caudal-to-cranial` (tail-to-head)
 - `dorsal-to-ventral` (back/top-to-belly/bottom)
 - `ventral-to-dorsal` (belly/bottom-to-back/top)
+
+**For layered and polarized tissues (subject-local):**
+- `superficial-to-deep` (outer surface to inner depth, e.g. skin, gut, cortex)
+- `deep-to-superficial` (inner depth to outer surface)
+- `apical-to-basal` (apical to basal surface, e.g. epithelial layers, polarized cells)
+- `basal-to-apical` (basal to apical surface)
+- `apex-to-base` (tip to broad base, e.g. heart, lungs)
+- `base-to-apex` (broad base to tip)
 
 Note: In bipeds, the terms rostral/caudal and dorsal/ventral are ambiguous because their orientation depends on the anatomical structure. For example, these directions are orthogonal when describing the human brain versus the spinal cord. Therefore, the unambiguous terms anterior/posterior and inferior/superior (sometimes referred to as head/foot) are generally preferred for bipeds.
 
@@ -204,6 +219,12 @@ Anatomical orientation refers to the specific arrangement and directional alignm
 | caudal-to-cranial | Describes the directional orientation from the tail (caudal) to the head (cranial) end of an anatomical structure or body. |  |  |
 | proximal-to-distal | Describes the directional orientation from the center of the body to the periphery of an anatomical structure or limb. |  |  |
 | distal-to-proximal | Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body. |  |  |
+| superficial-to-deep | Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex. |  |  |
+| deep-to-superficial | Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex. |  |  |
+| apical-to-basal | Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure. |  |  |
+| basal-to-apical | Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure. |  |  |
+| apex-to-base | Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung. |  |  |
+| base-to-apex | Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung. |  |  |
 
 ## Requirements
 
@@ -291,7 +312,13 @@ In JSON-Schema:
                         "cranial-to-caudal",
                         "caudal-to-cranial",
                         "proximal-to-distal",
-                        "distal-to-proximal"
+                        "distal-to-proximal",
+                        "superficial-to-deep",
+                        "deep-to-superficial",
+                        "apical-to-basal",
+                        "basal-to-apical",
+                        "apex-to-base",
+                        "base-to-apex"
                     ]
                 }
             },
@@ -355,6 +382,18 @@ class AnatomicalOrientationValue(str, Enum):
     proximal_to_distal = "proximal-to-distal"
     # Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body.
     distal_to_proximal = "distal-to-proximal"
+    # Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex.
+    superficial_to_deep = "superficial-to-deep"
+    # Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex.
+    deep_to_superficial = "deep-to-superficial"
+    # Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure.
+    apical_to_basal = "apical-to-basal"
+    # Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure.
+    basal_to_apical = "basal-to-apical"
+    # Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung.
+    apex_to_base = "apex-to-base"
+    # Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung.
+    base_to_apex = "base-to-apex"
 
 class Orientation(BaseModel):
     """
@@ -421,6 +460,18 @@ enum AnatomicalOrientationValue {
     proximal_to_distal = "proximal-to-distal",
     /** Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body. */
     distal_to_proximal = "distal-to-proximal",
+    /** Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex. */
+    superficial_to_deep = "superficial-to-deep",
+    /** Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex. */
+    deep_to_superficial = "deep-to-superficial",
+    /** Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure. */
+    apical_to_basal = "apical-to-basal",
+    /** Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure. */
+    basal_to_apical = "basal-to-apical",
+    /** Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung. */
+    apex_to_base = "apex-to-base",
+    /** Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung. */
+    base_to_apex = "base-to-apex",
 }
 ```
 
@@ -507,3 +558,4 @@ End-user applications SHOULD display the encoded information with, for example, 
 | 2025-07-23 | Clarify that the type fields are MUST's and the only currently defined value is "anatomical". | [https://github.com/ome/ngff/pull/329](https://github.com/ome/ngff/pull/329) |
 | 2025-07-23 | Use a Pydantic Literal for anatomical type | [https://github.com/ome/ngff/pull/330](https://github.com/ome/ngff/pull/330) |
 | 2026-01-20 | Clarify coordinate direction convention | [https://github.com/ome/ngff/pull/428](https://github.com/ome/ngff/pull/428) |
+| 2026-06-03 | Clarify subject-local vs. patient-global orientation and expand the controlled vocabulary with layered- and polarized-tissue terms (superficial/deep, apical/basal, apex/base), per [review 3](./reviews/3/index). | [https://github.com/ome/ngff/pull/435](https://github.com/ome/ngff/pull/435) |

--- a/rfc/4/index.md
+++ b/rfc/4/index.md
@@ -188,6 +188,8 @@ For images of biped or quadruped subjects, anatomical `orientation` SHOULD be ex
 
 If no orientation is specified, there is no implicit default value. Applications MAY assume a default orientation but SHOULD warn users that orientation metadata is expected but missing.
 
+An axis with no `orientation` field and an axis whose `orientation` is `null` are equivalent: in both cases the orientation of that axis is undefined. Consistent with the OME-Zarr convention that only fields which are present carry meaning, there is no semantic difference between an absent `orientation` and an explicit `null`, and neither implies a default value. Writers SHOULD omit the field rather than serialize `"orientation": null`.
+
 ## Coding Scheme
 
 We define the [LinkML encoding scheme](./orientation.yml) to enumerate the possible values
@@ -559,3 +561,4 @@ End-user applications SHOULD display the encoded information with, for example, 
 | 2025-07-23 | Use a Pydantic Literal for anatomical type | [https://github.com/ome/ngff/pull/330](https://github.com/ome/ngff/pull/330) |
 | 2026-01-20 | Clarify coordinate direction convention | [https://github.com/ome/ngff/pull/428](https://github.com/ome/ngff/pull/428) |
 | 2026-06-03 | Clarify subject-local vs. patient-global orientation and expand the controlled vocabulary with layered- and polarized-tissue terms (superficial/deep, apical/basal, apex/base), per [review 3](./reviews/3/index). | [https://github.com/ome/ngff/pull/435](https://github.com/ome/ngff/pull/435) |
+| 2026-06-04 | Clarify that an absent `orientation` and an explicit `null` `orientation` are equivalent and leave the orientation undefined. | [https://github.com/fideus-labs/ngff-zarr/pull/523](https://github.com/fideus-labs/ngff-zarr/pull/523) |

--- a/rfc/4/markdown/AnatomicalOrientationValues.md
+++ b/rfc/4/markdown/AnatomicalOrientationValues.md
@@ -31,4 +31,10 @@ URI: [ngff:AnatomicalOrientationValues](https://w3id.org/ome/ngff/AnatomicalOrie
 | caudal-to-cranial | Describes the directional orientation from the tail (caudal) to the head (cranial) end of an anatomical structure or body. |  |  |
 | proximal-to-distal | Describes the directional orientation from the center of the body to the periphery of an anatomical structure or limb. |  |  |
 | distal-to-proximal | Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body. |  |  |
+| superficial-to-deep | Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex. |  |  |
+| deep-to-superficial | Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex. |  |  |
+| apical-to-basal | Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure. |  |  |
+| basal-to-apical | Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure. |  |  |
+| apex-to-base | Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung. |  |  |
+| base-to-apex | Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung. |  |  |
 

--- a/rfc/4/orientation.py
+++ b/rfc/4/orientation.py
@@ -275,6 +275,30 @@ class AnatomicalOrientationValues(str, Enum):
     """
     Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body.
     """
+    superficial_to_deep = "superficial-to-deep"
+    """
+    Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex.
+    """
+    deep_to_superficial = "deep-to-superficial"
+    """
+    Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex.
+    """
+    apical_to_basal = "apical-to-basal"
+    """
+    Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure.
+    """
+    basal_to_apical = "basal-to-apical"
+    """
+    Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure.
+    """
+    apex_to_base = "apex-to-base"
+    """
+    Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung.
+    """
+    base_to_apex = "base-to-apex"
+    """
+    Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung.
+    """
 
 
 

--- a/rfc/4/orientation.schema.json
+++ b/rfc/4/orientation.schema.json
@@ -38,7 +38,13 @@
                 "cranial-to-caudal",
                 "caudal-to-cranial",
                 "proximal-to-distal",
-                "distal-to-proximal"
+                "distal-to-proximal",
+                "superficial-to-deep",
+                "deep-to-superficial",
+                "apical-to-basal",
+                "basal-to-apical",
+                "apex-to-base",
+                "base-to-apex"
             ],
             "title": "AnatomicalOrientationValues",
             "type": "string"

--- a/rfc/4/orientation.ts
+++ b/rfc/4/orientation.ts
@@ -133,6 +133,18 @@ export enum AnatomicalOrientationValues {
     proximal_to_distal = "proximal-to-distal",
     /** Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body. */
     distal_to_proximal = "distal-to-proximal",
+    /** Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex. */
+    superficial_to_deep = "superficial-to-deep",
+    /** Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex. */
+    deep_to_superficial = "deep-to-superficial",
+    /** Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure. */
+    apical_to_basal = "apical-to-basal",
+    /** Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure. */
+    basal_to_apical = "basal-to-apical",
+    /** Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung. */
+    apex_to_base = "apex-to-base",
+    /** Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung. */
+    base_to_apex = "base-to-apex",
 };
 
 

--- a/rfc/4/orientation.yml
+++ b/rfc/4/orientation.yml
@@ -328,3 +328,9 @@ enums:
       caudal-to-cranial: Describes the directional orientation from the tail (caudal) to the head (cranial) end of an anatomical structure or body.
       proximal-to-distal: Describes the directional orientation from the center of the body to the periphery of an anatomical structure or limb.
       distal-to-proximal: Describes the directional orientation from the periphery of an anatomical structure or limb to the center of the body.
+      superficial-to-deep: Describes the directional orientation from the outer surface (superficial) to the inner depth (deep) of a layered tissue such as skin, gut, or cortex.
+      deep-to-superficial: Describes the directional orientation from the inner depth (deep) to the outer surface (superficial) of a layered tissue such as skin, gut, or cortex.
+      apical-to-basal: Describes the directional orientation from the apical surface (apical) to the basal surface (basal) of an epithelial layer or polarized cell structure.
+      basal-to-apical: Describes the directional orientation from the basal surface (basal) to the apical surface (apical) of an epithelial layer or polarized cell structure.
+      apex-to-base: Describes the directional orientation from the tip (apex) to the broad base (base) of an organ such as the heart or lung.
+      base-to-apex: Describes the directional orientation from the broad base (base) to the tip (apex) of an organ such as the heart or lung.


### PR DESCRIPTION
Follow-up to RFC-4 **review 3** (Dave Horsfall, Hannifa Lab; added in ome/ngff#435), implementing its two accepted recommendations. The review was generated from a Hannifa Lab discussion spanning wet-lab scientists, clinicians, bioinformaticians, and engineers, and recommended "Accept, with minor changes: explicitly support subject-local orientation and expand the vocabulary to include layered-tissue terms."

## What changed

**1. New "Subject-Local vs. Patient-Global Orientation" clarification** (`rfc/4/index.md`)

Clarifies that the orientation *subject* need not be a whole organism — it may be a local anatomical structure such as a tissue biopsy, histology slide, or dissected organ. The existing "roughly aligned to the imaging axes" requirement is reinterpreted to apply to the local tissue structure, and RFC-5 transformations are cited for relating subject-local axes to a patient-global / atlas frame when such a registration is available.

**2. Six new controlled-vocabulary terms for layered and polarized tissues** (anatomical vocabulary grows 18 → 24 values)

| Pair | Intended use |
| --- | --- |
| `superficial-to-deep` / `deep-to-superficial` | layered tissues (skin, gut, cortex) |
| `apical-to-basal` / `basal-to-apical` | epithelial layers, polarized cell structures |
| `apex-to-base` / `base-to-apex` | organs such as the heart or lungs |

**3. Removed the now-redundant `histological: basal/apical` future-domain example**, since basal/apical are now part of the anatomical vocabulary.

## Why

In spatial transcriptomics, histopathology, and high-resolution histology, the imaged subject is frequently a tissue specimen whose global position/orientation on the donor is unknown, but whose internal orientation is well defined — e.g. a skin biopsy's depth axis is `superficial-to-deep` regardless of where on the body it was taken. The prior wording was geared toward whole-patient imaging; these changes make the `orientation` field usable by the tissue-profiling community without requiring full patient-to-atlas registration, and supply the layered/polarized-tissue terms that community needs.

## Implementation details

- The six values were added to the LinkML **source of truth** (`rfc/4/orientation.yml`) and propagated **consistently** to every derived artifact — `orientation.schema.json`, `orientation.py`, `orientation.ts`, `markdown/AnatomicalOrientationValues.md` — and to every representation embedded in `index.md` (controlled-vocabulary list, permissible-values table, JSON-Schema, Pydantic, and TypeScript snippets). A new "layered and polarized tissues" category was added to the vocabulary list and a `2026-06-03` changelog entry references review 3.
- Derived files were **hand-edited rather than regenerated**: the locally available LinkML (metamodel `1.11.0`) diverges from the committed output (`1.7.0`) and regeneration would have introduced unrelated abstract-class/version noise. The updated `orientation.yml` was nonetheless verified to still generate cleanly through LinkML (all six values present, no errors).
- The frozen review snapshot under `rfc/4/versions/` was intentionally left untouched.

## Verification

- All 24 vocabulary values consistent across every file; identical ordering in `.py` / `.ts` / `.json`; hyphenated values vs. underscored identifiers correct.
- `orientation.schema.json` is valid JSON, `orientation.yml` valid YAML, `orientation.py` compiles, and the RFC page parses under MyST with no new errors.
- `codespell` clean; CodeRabbit review reported 0 findings.

## Out of scope

Review 3's third discussion point — a deeper RFC-4 ↔ RFC-5 semantic bridge for programmatic atlas registration — is left for future collaboration, as the reviewer suggested. The RFC's existing "Interaction with RFC-5" section already covers the basic relationship.
