### PR TITLE
fix: bikeshed build and template

### DIFF
--- a/boilerplate/copyright.include
+++ b/boilerplate/copyright.include
@@ -1,0 +1,4 @@
+Copyright © 2020-[YEAR]
+<a href="https://www.openmicroscopy.org/"><abbr title="Open Microscopy Environment">OME</abbr></a><sup>®</sup>
+(<a href="https://dundee.ac.uk/"><abbr title="University of Dundee">U. Dundee</abbr></a>).
+OME trademark rules apply.

--- a/boilerplate/header.include
+++ b/boilerplate/header.include
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>[TITLE]</title>
+  <style data-fill-with="stylesheet">
+  </style>
+</head>
+<body class="h-entry">
+<div class="head">
+
+  <img src="http://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME logo (6 circles in a hexagon)" style="float:right;width:42px;height:42px;">
+
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <div data-fill-with="spec-metadata"></div>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<div class="p-summary" data-fill-with="abstract"></div>
+
+<h2 class='no-num no-toc no-ref' id='sotd'>Status of this document</h2>
+<div data-fill-with="status"></div>
+<div data-fill-with="at-risk"></div>
+
+<nav data-fill-with="table-of-contents" id="toc"></nav>
+<main>

--- a/conf.py
+++ b/conf.py
@@ -17,15 +17,12 @@ extensions = [
     "myst_parser",
     "sphinx_reredirects",
     "sphinx_design",
-    "sphinxcontrib.bibtex"]
+    "sphinxcontrib.bibtex",
+]
 bibtex_bibfiles = ["references.bib"]
 source_suffix = [".rst", ".md"]
 myst_heading_anchors = 5
-myst_enable_extensions = [
-    "deflist",
-    "strikethrough",
-    "colon_fence"
-    ]
+myst_enable_extensions = ["deflist", "strikethrough", "colon_fence"]
 
 templates_path = ["_templates"]
 exclude_patterns = [
@@ -57,7 +54,7 @@ redirects = {
     "latest/index": "../specifications/0.5/index.html",
     "latest/": "../specifications/0.5/index.html",
     "dev/index": "../specifications/dev/index.html",
-    "dev/": "../specifications/dev/index.html"
+    "dev/": "../specifications/dev/index.html",
 }
 
 # -- Options for HTML output -------------------------------------------------
@@ -93,6 +90,7 @@ html_extra_path = [
     "_html_extra",
 ]
 
+
 def build_served_html():
     import glob
     import subprocess
@@ -102,34 +100,58 @@ def build_served_html():
     from pathlib import Path
 
     os.chdir(Path(__file__).parent)
-    versions = [d for d in os.listdir("specifications") if os.path.isdir(os.path.join("specifications", d))]
+    versions = [
+        d
+        for d in os.listdir("specifications")
+        if os.path.isdir(os.path.join("specifications", d))
+    ]
 
     for version in versions:
 
         # copy schemas to _html_extra
-        os.makedirs(f'_html_extra/{version}/schemas', exist_ok=True)
-        schemas = glob.glob(f'specifications/{version}/**/*.schema', recursive=True)
+        os.makedirs(f"_html_extra/{version}/schemas", exist_ok=True)
+        schemas = glob.glob(f"specifications/{version}/**/*.schema", recursive=True)
         for schema in schemas:
-            shutil.copy2(schema, f'_html_extra/{version}/schemas/')
-        print(f'✅ Copied schemas for version {version}')
-    
+            shutil.copy2(schema, f"_html_extra/{version}/schemas/")
+        print(f"✅ Copied schemas for version {version}")
+
         # find 'pre_build.py' in 'specifications' subdirectories
-        script = glob.glob(f'specifications/{version}/**/pre_build.py', recursive=True)[0]
+        script = glob.glob(f"specifications/{version}/**/pre_build.py", recursive=True)[
+            0
+        ]
+
+        # Inject shared OME boilerplate next to index.bs so the legacy Bikeshed
+        # build renders OME branding instead of falling back to the W3C default.
+        # Kept here in the superproject so we never have to edit, commit, and
+        # bump every ngff-spec version submodule (the includes were lost exactly
+        # that way during the ngff -> ngff-spec migration).
+        spec_dir = os.path.dirname(script)
+        for inc in ("header.include", "copyright.include"):
+            src = os.path.join("boilerplate", inc)
+            if os.path.exists(src):
+                shutil.copy2(src, os.path.join(spec_dir, inc))
+                print(f"✅ Injected {inc} for version {version}")
+            else:
+                print(
+                    f"⚠️  Missing boilerplate/{inc}; {version} will use Bikeshed defaults"
+                )
 
         subprocess.check_call([sys.executable, script])
-        print('✅ Built rendered examples/schemas for version', version)
+        print("✅ Built rendered examples/schemas for version", version)
 
         # build jupyter-book docs in specification submodules
-        myst_file = glob.glob(f'specifications/{version}/**/myst.yml', recursive=True)[0]
-        bikeshed_output = f'specifications/{version}/index.html'
+        myst_file = glob.glob(f"specifications/{version}/**/myst.yml", recursive=True)[
+            0
+        ]
+        bikeshed_output = f"specifications/{version}/index.html"
 
         # copy built html files to _html_extra
         try:
             if os.path.exists(bikeshed_output):
-                shutil.copy2(bikeshed_output, f'_html_extra/{version}/index.html')
-                print(f'✅ Found legacy bikeshed, serving as extra html for {version}')
+                shutil.copy2(bikeshed_output, f"_html_extra/{version}/index.html")
+                print(f"✅ Found legacy bikeshed, serving as extra html for {version}")
         except Exception as e:
-            print(f'⚠️  Could not copy served html for version {version}: {e}')
+            print(f"⚠️  Could not copy served html for version {version}: {e}")
+
 
 build_served_html()
-    

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
     nodejs: "22"
 
 submodules:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bikeshed<4.2
+bikeshed
 myst-parser
 pydata-sphinx-theme
 json-schema-for-humans


### PR DESCRIPTION
see e.g. https://ngff-readd-boilerplate.readthedocs.io/en/latest/0.2/

(the url churn is from readthedocs, it will go away on ngff.openmicroscopy.org) 

current ngff.o.org: 
<img width="1613" height="585" alt="grafik" src="https://github.com/user-attachments/assets/968b932f-836f-4f20-823c-d5d0bcfa6f39" />

this fix: 
<img width="933" height="529" alt="grafik" src="https://github.com/user-attachments/assets/af3fae64-df94-4782-8b85-00996c25233b" />


