### PR TITLE
Improve "Publications" page and add minor clean-ups in the front page

### DIFF
--- a/.github/workflows/html-proofer.yml
+++ b/.github/workflows/html-proofer.yml
@@ -1,10 +1,29 @@
 name: "Build and Lint Site"
 
 on:
-  push:
-    branches: ["main"]
+  workflow_dispatch:
   pull_request:
     branches: ["main"]
+    paths:
+      - "specifications/**"
+      - "rfc/**"
+      - "resources/**"
+      - "community/**"
+      - "contributing/**"
+      - "help-desk/**"
+      - "_html_extra/**"
+      - "_static/**"
+      - "_ext/**"
+      - "images/**"
+      - "**/*.md"
+      - "conf.py"
+      - "requirements.txt"
+      - "readthedocs.yml"
+      - ".github/workflows/build-lint.yml"
+
+concurrency:
+  group: build-lint-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-site:
@@ -13,36 +32,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       # dependencies
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: actions/setup-node@v4
         with:
-          node-version: "19"
+          node-version: "22"
+
       - name: Install dependencies
-        working-directory: ./docs
         run: |
-          pip install 
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install
+          pip install -r requirements.txt
+          pip install specifications/dev
+          gem install html-proofer
 
       - name: Build the site
-        working-directory: ./docs
-        run: bundle exec jekyll build --future --strict_front_matter
+        run: sphinx-build -b html . _build/html
 
       - name: Validate all links, enforce alt text
-        working-directory: ./docs
-        run: |
-          bundle exec htmlproofer --ignore-files "/.*\/specifications\/(0\.[0-9]+|dev)\/.*/,/.*webpack-macros\.html/,/.*\/rfc\/4\/markdown\/.*/,/.*\/rfc\/5\/.*/,/.*\/rfc\/1\/.*/,/.*\/0\.[0-9]+(\.html|\/.*)/,/.*\/ro-crate-preview\.html/,/.*\/examples\/.*\/index\.html/" --disable-external true --enforce-https false --swap-urls '^/ro-crate/:/' ./_site
-      - name: Ensure no unexpected encoded HTML in output
-        working-directory: ./docs
-        run: |
-          ! fgrep -R 'lt;blockquote' _site
+        run: htmlproofer --ignore-files "/.*\/specifications\/(0\.[0-9]+|dev)\/.*/,/.*webpack-macros\.html/,/.*\/rfc\/4\/markdown\/.*/,/.*\/rfc\/5\/.*/,/.*\/rfc\/1\/.*/,/.*\/0\.[0-9]+(\.html|\/.*)/" --disable-external ./_build/html
 
-      - name: Ensure no unexpected jekyll in output
-        working-directory: ./docs
+      - name: Ensure no unexpected encoded HTML in output
         run: |
-          ! fgrep -R 'site.pages' _site
+          ! fgrep -R 'lt;blockquote' _build/html

--- a/.github/workflows/html-proofer.yml
+++ b/.github/workflows/html-proofer.yml
@@ -1,0 +1,48 @@
+name: "Build and Lint Site"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # dependencies
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "19"
+      - name: Install dependencies
+        working-directory: ./docs
+        run: |
+          pip install 
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install
+
+      - name: Build the site
+        working-directory: ./docs
+        run: bundle exec jekyll build --future --strict_front_matter
+
+      - name: Validate all links, enforce alt text
+        working-directory: ./docs
+        run: |
+          bundle exec htmlproofer --ignore-files "/.*\/specifications\/(0\.[0-9]+|dev)\/.*/,/.*webpack-macros\.html/,/.*\/rfc\/4\/markdown\/.*/,/.*\/rfc\/5\/.*/,/.*\/rfc\/1\/.*/,/.*\/0\.[0-9]+(\.html|\/.*)/,/.*\/ro-crate-preview\.html/,/.*\/examples\/.*\/index\.html/" --disable-external true --enforce-https false --swap-urls '^/ro-crate/:/' ./_site
+      - name: Ensure no unexpected encoded HTML in output
+        working-directory: ./docs
+        run: |
+          ! fgrep -R 'lt;blockquote' _site
+
+      - name: Ensure no unexpected jekyll in output
+        working-directory: ./docs
+        run: |
+          ! fgrep -R 'site.pages' _site

--- a/README.md
+++ b/README.md
@@ -14,16 +14,9 @@ See also [CONTRIBUTING.md](./contributing/index.md)
 
 Specifications have been moved to [ome/ngff-spec](https://github.com/ome/ngff-spec).
 
-### Editing specifications
-
-Specifications are written in markdown, or technically
-[bikeshed](https://github.com/tabatkins/bikeshed) -- a markdown document, with
-special extensions understood by the bikeshed tool. The bikeshed tool is run
-during the Sphinx build step (see conf.py).
-
 # RFCs
 
-Requests for comments (RFCs) are used to discuss and capture high-level decisions within the NGFF community. 
+Requests for comments (RFCs) are used to discuss and capture high-level decisions within the NGFF community.
 
 RFCs are contained under the `rfc` directory at the moment but may be moved out into a separate repo in the future.
 
@@ -37,5 +30,3 @@ RFCs are contained under the `rfc` directory at the moment but may be moved out 
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-
-

--- a/boilerplate/header.include
+++ b/boilerplate/header.include
@@ -10,7 +10,7 @@
 <body class="h-entry">
 <div class="head">
 
-  <img src="http://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME logo (6 circles in a hexagon)" style="float:right;width:42px;height:42px;">
+  <img src="https://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME logo (6 circles in a hexagon)" style="float:right;width:42px;height:42px;">
 
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],

--- a/contributing/specification/index.md
+++ b/contributing/specification/index.md
@@ -6,7 +6,7 @@ request for comment (RFC) documents.
 
 In the future we will flesh out this page with a guide to RFCs, but in the
 meantime the RFC process is outlined in the
-[Implementation section of RFC 1](../rfc/1/index.md#implementation).
+[Implementation section of RFC 1](rfc1-implementation).
 
 ## Comment on a Request For Comment (RFC)
 

--- a/contributing/specification/index.md
+++ b/contributing/specification/index.md
@@ -13,7 +13,7 @@ meantime the RFC process is outlined in the
 If you want to leave a suggestion or comment on an RFC that is under review,
 please leave a comment in a new page under the "comments/" directory for the
 relevant RFC. A template is also available for formatting your comment:
-[template](../rfc/1/templates/review_template).
+[template](rfc1-review-template).
 
 ## How to change the specification
 
@@ -143,7 +143,7 @@ Other useful admonitions and directives (e.g., `hint`, `note`) can be found [her
 
 ## Building *only* the spec document
 
-The spec document under the [ngff-spec](github.com/ome/ngff-spec) repository can be built as a standalone document to make writing and rendering a smoother experience.
+The spec document under the [ngff-spec](https://github.com/ome/ngff-spec) repository can be built as a standalone document to make writing and rendering a smoother experience.
 To build the spec document, you first need to install the necessary dependencies:
 
 After cloning the ngff-spec repo, navigate into the repository on your machine and install the dependencies using pip:

--- a/help-desk/index.md
+++ b/help-desk/index.md
@@ -91,7 +91,7 @@ Jump to:
 
 **OME-NGFF** - OME-NGFF refers to the resulting efforts of the OME & NGFF communities.
 
-**OME-Zarr** - An OME-Zarr is a standardized file format for microscopy images. More details on the [main page](#../).
+**OME-Zarr** - An OME-Zarr is a standardized file format for microscopy images. More details on the [main page](#main-page).
 
 [Back to top](#glossary)
 
@@ -147,7 +147,7 @@ Jump to:
 
 ### Z
 
-**Zarr** -- A file format, see the [main page](#../) for more information about what a Zarr is and the benefits of using Zarr.
+**Zarr** -- A file format, see the [main page](#main-page) for more information about what a Zarr is and the benefits of using Zarr.
 
 **Zarr Group** - A Zarr group is like a folder inside a dataset. It can hold arrays, metadata, or other groups, helping organize complex data into a clear hierarchy. Think of it as a way to keep all related images and information neatly together.
 
@@ -212,6 +212,7 @@ That is often the case. OME-Zarr include multiresolution data (i.e. pyramids), w
 
 Not yet fully. Some workarounds are possible (1D arrays, mesh formats), but this is an active area of development.
 
+(where-to-seek-for-help)=
 ## Where to look for help
 
 If you have questions or need help with OME-Zarr, you can reach out through the following channels:

--- a/help-desk/index.md
+++ b/help-desk/index.md
@@ -1,8 +1,8 @@
 # Help Desk
 
-* [Glossary](#glossary)
-* [FAQs](#faqs)
-* [Where to seek for help](#where-to-seek-for-help)
+- [Glossary](#glossary)
+- [FAQs](#faqs)
+- [Where to seek for help](#where-to-seek-for-help)
 
 ## Glossary
 
@@ -29,11 +29,23 @@ Jump to:
 
 [Back to top](#glossary)
 
+### D
+
+[Back to top](#glossary)
+
+### E
+
+[Back to top](#glossary)
+
+### F
+
+[Back to top](#glossary)
+
 ### G
 
 [Back to top](#glossary)
 
-### H 
+### H
 
 **HCS** - Dedicated layout of OME-Zarr files representing the used wells and plates for High Content Screening (HCS). The layout allows a user to efficiently address and analyze specific data from specific wells.
 
@@ -41,9 +53,21 @@ Jump to:
 
 [Back to top](#glossary)
 
+### I
+
+[Back to top](#glossary)
+
 ### J
 
 **JSON file** - A simple standardized human-readable data format for sharing data using nested key-value pairs.
+
+[Back to top](#glossary)
+
+### K
+
+[Back to top](#glossary)
+
+### L
 
 [Back to top](#glossary)
 
@@ -54,6 +78,7 @@ Jump to:
 [Back to top](#glossary)
 
 ### N
+
 **NGFF** - Next Generation File Format (NGFF) is a community for solving problems related to producing open-source software for microscopy data.
 
 [Back to top](#glossary)
@@ -76,6 +101,10 @@ Jump to:
 
 [Back to top](#glossary)
 
+### Q
+
+[Back to top](#glossary)
+
 ### R
 
 **RFC** - Request For Comments (RFC) is a process for proposing a change to the standardized specification for OME-Zarr files.
@@ -84,7 +113,7 @@ Jump to:
 
 ### S
 
-**Shard/ing** - Like [Chunks](#c), sharding is a way of breaking up pixel data for more efficient access. Shards are groups of chunks with headers in front of them for describing the chunks inside.
+**Shard/ing** - Like [Chunks](#c), sharding is a way of breaking up pixel data for more efficient access. Shards are groups of chunks in a single object with headers describing the chunks inside.
 
 [Back to top](#glossary)
 
@@ -96,12 +125,23 @@ Jump to:
 
 ### U
 
+[Back to top](#glossary)
+
+### V
 
 [Back to top](#glossary)
 
 ### W
 
 **Workflow** - A structured sequence of tasks designed to achieve a specific goal. In the case of OME-Zarr, a workflow is some sequence of tasks usually used for performing some type of analysis on the image data.
+
+[Back to top](#glossary)
+
+### X
+
+[Back to top](#glossary)
+
+### Y
 
 [Back to top](#glossary)
 
@@ -172,15 +212,13 @@ That is often the case. OME-Zarr include multiresolution data (i.e. pyramids), w
 
 Not yet fully. Some workarounds are possible (1D arrays, mesh formats), but this is an active area of development.
 
-
-
 ## Where to look for help
+
 If you have questions or need help with OME-Zarr, you can reach out through the following channels:
-| Where | Description | When to use  |
+| Where | Description | When to use |
 |-------|-------------| --------------|
-| [Image.sc Forum](https://forum.image.sc) | A community forum for image analysis and bioimaging. | To know when to use the tags [ngff](https://forum.image.sc/tag/ngff), [ome-ngff](https://forum.image.sc/tag/ome-ngff),  and [ome-zarr](https://forum.image.sc/tag/ome-zarr) in the forum please read [Landing Page](https://ngff.openmicroscopy.org/index.html), Glossary and FAQs in this page. |
+| [Image.sc Forum](https://forum.image.sc) | A community forum for image analysis and bioimaging. | To know when to use the tags [ngff](https://forum.image.sc/tag/ngff), [ome-ngff](https://forum.image.sc/tag/ome-ngff), and [ome-zarr](https://forum.image.sc/tag/ome-zarr) in the forum please read [Landing Page](https://ngff.openmicroscopy.org/index.html), Glossary and FAQs in this page. |
 | [ome/ngff GitHub Issues](https://github.com/ome/ngff/issues) | The official repository for OME-NGFF specifications and related discussions. | For reporting bugs, suggesting features, or discussing technical aspects of the OME-NGFF specifications. |
 | Office Hours | Regularly scheduled virtual meetings where you can ask questions and get help from the NGFF community | Office hours rotate between APAC/AU/EU- and AMER/AU/EU-friendly times. Join them when you want to chat about OME-Zarr. Read more in the [Community](../community/index.md) page. |
 | OME-Zarr libraries GitHub Issues| Various repositories for OME-Zarr libraries. | For issues specific to a particular OME-Zarr library, use the respective GitHub repository's issue. |
 | In person events | Conferences, workshops, and meetups where you can connect with the NGFF community. | To network, learn, and discuss OME-Zarr in person. Check the [Community](../community/index.md) page for upcoming events. |
-

--- a/index.md
+++ b/index.md
@@ -15,12 +15,12 @@ In summary, OME-Zarr allows you to store, share and stream large images. You can
 An OME-Zarr is a file format optimized for storing, viewing, & sharing large images.
 There are two parts to an OME-Zarr:
 
-* **The "Zarr" part describes how the pixel data for the images are laid out**
-* **The "OME" part, which stands for [Open Microscopy Environment](https://www.openmicroscopy.org/), describes metadata about the pixel data. This includes metadata such as:
-  * spatial relationships
-  * high content screening data
-  * well data
-  * [and more](./specifications/index)!
+- **The "Zarr" part describes how the pixel data for the images are laid out**. [Zarr](https://zarr.dev) is a next-generation data format used for scientific datasets in multiple domains.
+- **The "OME" part describes metadata about the pixel data.** OME stands for [Open Microscopy Environment](https://www.openmicroscopy.org/). This includes metadata such as:
+  - spatial relationships
+  - high content screening data
+  - well data
+  - [and more](./specifications/index)!
 
 ## Why would I use OME-Zarr?
 
@@ -28,14 +28,14 @@ In general, OME-Zarr is growing as a default [FAIR](https://en.wikipedia.org/wik
 
 OME-Zarr files have two major benefits:
 
-* **Standardization:** "OME-Zarr" is a "Zarr" with embedded standardized metadata in the Open Microscopy Environment (OME) format.
-  * **_Sharing_**: It eases cross-organization file sharing, aiding organizational collaboration and data sharing. Repositories like the [Image Data Resource](https://idr.openmicroscopy.org/) and [BioImage Archive](https://www.ebi.ac.uk/bioimage-archive/) are currently migrating to having OME-Zarr as a standard format for _all_ their data.
-  * **_Interoperability_**: Standardized metadata enables the ability to "mix and match" tools from different organizations, benefiting from the strengths of multiple tools as needed.
+- **Standardization:** "OME-Zarr" is a "Zarr" with embedded standardized metadata in the Open Microscopy Environment (OME) format.
+  - **_Sharing_**: It eases cross-organization file sharing, aiding organizational collaboration and data sharing. Repositories like the [Image Data Resource](https://idr.openmicroscopy.org/) and [BioImage Archive](https://www.ebi.ac.uk/bioimage-archive/) are currently migrating to having OME-Zarr as a standard format for _all_ their data.
+  - **_Interoperability_**: Standardized metadata enables the ability to "mix and match" tools from different organizations, benefiting from the strengths of multiple tools as needed.
 
-* **Parallel access**: Chunking is inherent to "Zarr" files. This means "Zarr" files are stored in independently-accessible blocks.
-  * **_Storage_**: Microscopy images can be quite large and can therefore reach Cloud system storage limits for individual files; the chunked nature of a Zarr can alleviate this issue. Some storage systems may also duplicate byte-equivalent files, so a chunked file like Zarr may save storage space.
-  * **_Viewing_**: Viewers can target specific chunks to load based upon the current view, reducing lag, & enabling massive images to be viewed within browsers.
-  * **_Cost_**: When viewing or reading data, the total cost of accessing a Zarr file on the cloud may be less than a more monolithic file format due to the more efficient data access patterns. Ex. A viewer can just access the chunks of the image it needs to display rather than the entire image.
+- **Parallel access**: Chunking is inherent to "Zarr" files. This means "Zarr" files are stored in independently-accessible blocks.
+  - **_Storage_**: Microscopy images can be quite large and can therefore reach Cloud system storage limits for individual files; the chunked nature of a Zarr can alleviate this issue. Some storage systems may also duplicate byte-equivalent files, so a chunked file like Zarr may save storage space.
+  - **_Viewing_**: Viewers can target specific chunks to load based upon the current view, reducing lag, & enabling massive images to be viewed within browsers.
+  - **_Cost_**: When viewing or reading data, the total cost of accessing a Zarr file on the cloud may be less than a more monolithic file format due to the more efficient data access patterns. Ex. A viewer can just access the chunks of the image it needs to display rather than the entire image.
 
 Of note, both benefits contribute to **_AI-readiness_**: the standardized metadata & access patterns provide a common layer for machine-learning workflows, reducing the friction for developers to build and test models.
 
@@ -45,33 +45,33 @@ The [tools](./tools/index), [data](./data/index), and [ecosystem](./ecosystem/in
 
 While the format matures, it may be frustrating to use OME-Zarr in some cases, for example:
 
-* If you are working with small images, not planning to share them and your current tools already work well, then using OME-Zarr may not be necessary. Planned expansions to the specification (such as single-file Zarrs) will make it more convenient in these scenarios.
+- If you are working with small images, not planning to share them and your current tools already work well, then using OME-Zarr may not be necessary. Planned expansions to the specification (such as single-file Zarrs) will make it more convenient in these scenarios.
 
-* If you need specific conditions for which OME-Zarr support is not mature, you may need to use a different file format.
-  * Particularly, if your original file is lossy compressed, you will see a large increase in file size (about an order of magnitude) as the images are decompressed into OME-Zarr, since transferring lossy compressed tiles is not yet supported. This currently impacts most whole slide image (WSI) formats such as SVS, CZI, and NDPI, which are lossy JPEG compressed by default.
+- If you need specific conditions for which OME-Zarr support is not mature, you may need to use a different file format.
+  - Particularly, if your original file is lossy compressed, you will see a large increase in file size (about an order of magnitude) as the images are decompressed into OME-Zarr, since transferring lossy compressed tiles is not yet supported. This currently impacts most whole slide image (WSI) formats such as SVS, CZI, and NDPI, which are lossy JPEG compressed by default.
 
 ## Who is using OME-Zarr?
 
 These are _some_ of the organizations (and their dataset pages) that are using OME-Zarr for their data.
 
-* [Allen Institute](https://bff.allencell.org/datasets)
-* biohub
-* [Broad Institute](https://broadinstitute.github.io/cellpainting-gallery/overview.html)
-* [EMBL - Image Data Resource (IDR)](https://idr.openmicroscopy.org/)
-* [Howard Hughes Medical Institute, Janelia (HHMI)](https://openorganelle.janelia.org/)
-* [Jackson Laboratory (JAX)](https://images.jax.org/)
-* ... [and more](./data/index)
+- [Allen Institute](https://bff.allencell.org/datasets)
+- biohub
+- [Broad Institute](https://broadinstitute.github.io/cellpainting-gallery/overview.html)
+- [EMBL - Image Data Resource (IDR)](https://idr.openmicroscopy.org/)
+- [Howard Hughes Medical Institute, Janelia (HHMI)](https://openorganelle.janelia.org/)
+- [Jackson Laboratory (JAX)](https://images.jax.org/)
+- ... [and more](./data/index)
 
 ## How do I use OME-Zarr?
 
-* Already have a Zarr?
-  * Check out the [tools section](./tools/index)!
-* Want to create a Zarr?
-  * Check out the [tools section](./tools/index)!
-* Want to see or download a Zarr?
-  * Check out the [data section](./data/index)!
-* Want to cite OME-Zarr/NGFF in your work?
-  * Check out the [publications section](./publications/index)!
+- Already have a Zarr?
+  - Check out the [tools section](./tools/index)!
+- Want to create a Zarr?
+  - Check out the [tools section](./tools/index)!
+- Want to see or download a Zarr?
+  - Check out the [data section](./data/index)!
+- Want to cite OME-Zarr/NGFF in your work?
+  - Check out the [publications section](./publications/index)!
 
 ## Have other questions?
 

--- a/index.md
+++ b/index.md
@@ -1,3 +1,4 @@
+(main-page)=
 # Next-Generation File Formats (NGFF) + OME-Zarr
 
 Welcome to the Next-Generation File Formats (NGFF) main page! This site is dedicated to providing resources for the NGFF community and those that are interested in getting started with OME-Zarr.
@@ -39,7 +40,7 @@ OME-Zarr files have two major benefits:
 
 Of note, both benefits contribute to **_AI-readiness_**: the standardized metadata & access patterns provide a common layer for machine-learning workflows, reducing the friction for developers to build and test models.
 
-The [tools](./tools/index), [data](./data/index), and [ecosystem](./ecosystem/index) may provide a better sense of the range of scientific use cases that may benefit from OME-Zarr. The [publications](./publications/index) page provides a list of publications that have used OME-Zarr in their work.
+The [tools](#resources-tools), [data](#resources-data), and [ecosystem](#resources-ecosystem) may provide a better sense of the range of scientific use cases that may benefit from OME-Zarr. The [publications](#resources-publications) page provides a list of publications that have used OME-Zarr in their work.
 
 ## When would I not use OME-Zarr?
 
@@ -60,18 +61,18 @@ These are _some_ of the organizations (and their dataset pages) that are using O
 - [EMBL - Image Data Resource (IDR)](https://idr.openmicroscopy.org/)
 - [Howard Hughes Medical Institute, Janelia (HHMI)](https://openorganelle.janelia.org/)
 - [Jackson Laboratory (JAX)](https://images.jax.org/)
-- ... [and more](./data/index)
+- ... [and more](#resources-data)
 
 ## How do I use OME-Zarr?
 
 - Already have a Zarr?
-  - Check out the [tools section](./tools/index)!
+  - Check out the [tools section](#resources-tools)!
 - Want to create a Zarr?
-  - Check out the [tools section](./tools/index)!
+  - Check out the [tools section](#resources-tools)!
 - Want to see or download a Zarr?
-  - Check out the [data section](./data/index)!
+  - Check out the [data section](#resources-data)!
 - Want to cite OME-Zarr/NGFF in your work?
-  - Check out the [publications section](./publications/index)!
+  - Check out the [publications section](#resources-publications)!
 
 ## Have other questions?
 

--- a/index.md
+++ b/index.md
@@ -16,49 +16,62 @@ An OME-Zarr is a file format optimized for storing, viewing, & sharing large ima
 There are two parts to an OME-Zarr:
 
 * **The "Zarr" part describes how the pixel data for the images are laid out**
-* The "OME", which stands for [Open Microscopy Environment](https://www.openmicroscopy.org/), part describes metadata about the pixel data. This includes metadata such as:
-   * spatial relationships
-   * high content screening data
-   * well data
-   * [and more](./specifications/index)!
+* **The "OME" part, which stands for [Open Microscopy Environment](https://www.openmicroscopy.org/), describes metadata about the pixel data. This includes metadata such as:
+  * spatial relationships
+  * high content screening data
+  * well data
+  * [and more](./specifications/index)!
 
 ## Why would I use OME-Zarr?
 
+In general, OME-Zarr is growing as a default [FAIR](https://en.wikipedia.org/wiki/FAIR_data) choice for storing and sharing microscopy images.
+
 OME-Zarr files have two major benefits:
 
-* Chunking is inherent to "Zarr" files. This means "Zarr" files are stored in independently-accessible blocks.
-   * **Storage**: Microscopy images can be quite large and can therefore reach Cloud system storage limits for individual files; the chunked nature of a Zarr can alleviate this issue. Some storage systems may also duplicate byte-equivalent files, so a chunked file like Zarr may save storage space.
-   * **Viewing**: Viewers can target specific chunks to load based upon the current view, reducing lag, & enabling massive images to be viewed within browsers.
-   * **Cost**: When viewing or reading data, the total cost of accessing a Zarr file on the cloud may be less than a more monolithic file format due to the more efficient data access patterns. Ex. A viewer can just access the chunks of the image it needs to display rather than the entire image.
-* "OME-Zarr" is a "Zarr" with embedded standardized metadata in the Open Microscopy Environment (OME) format.
-   * **Sharing**: A standardized imaging metadata format can ease cross-organization file sharing and can therefore aid organizational collaboration and data sharing.
-   * **Interoperability**: Standardized metadata can also enable the interoperability of tools.
+* **Standardization:** "OME-Zarr" is a "Zarr" with embedded standardized metadata in the Open Microscopy Environment (OME) format.
+  * **_Sharing_**: It eases cross-organization file sharing, aiding organizational collaboration and data sharing. Repositories like the [Image Data Resource](https://idr.openmicroscopy.org/) and [BioImage Archive](https://www.ebi.ac.uk/bioimage-archive/) are currently migrating to having OME-Zarr as a standard format for _all_ their data.
+  * **_Interoperability_**: Standardized metadata enables the ability to "mix and match" tools from different organizations, benefiting from the strengths of multiple tools as needed.
+
+* **Parallel access**: Chunking is inherent to "Zarr" files. This means "Zarr" files are stored in independently-accessible blocks.
+  * **_Storage_**: Microscopy images can be quite large and can therefore reach Cloud system storage limits for individual files; the chunked nature of a Zarr can alleviate this issue. Some storage systems may also duplicate byte-equivalent files, so a chunked file like Zarr may save storage space.
+  * **_Viewing_**: Viewers can target specific chunks to load based upon the current view, reducing lag, & enabling massive images to be viewed within browsers.
+  * **_Cost_**: When viewing or reading data, the total cost of accessing a Zarr file on the cloud may be less than a more monolithic file format due to the more efficient data access patterns. Ex. A viewer can just access the chunks of the image it needs to display rather than the entire image.
+
+Of note, both benefits contribute to **_AI-readiness_**: the standardized metadata & access patterns provide a common layer for machine-learning workflows, reducing the friction for developers to build and test models.
+
+The [tools](./tools/index), [data](./data/index), and [ecosystem](./ecosystem/index) may provide a better sense of the range of scientific use cases that may benefit from OME-Zarr. The [publications](./publications/index) page provides a list of publications that have used OME-Zarr in their work.
 
 ## When would I not use OME-Zarr?
 
-* If your file isn't very big and you're working with local data, the current specification of OME-Zarr can be less convenient than a single-file format and the benefits are limited. Planned expansions to the OME-Zarr specification will make it more convenient to work with it in these scenarios (e.g. single-file Zarrs) and add features that might make it beneficial to use OME-Zarr even in these scenarios (e.g. transformations).
-* If your original file is lossy compressed, you will see a large increase in file size as the images are decompressed into OME-Zarr. There is not yet support for transferring lossy compressed image tiles to OME-Zarr. This currently impacts most whole slide image (WSI) formats such as SVS, CZI, and NDPI, which are lossy JPEG compressed by default and see about a 10x size increase into OME-Zarr.
+While the format matures, it may be frustrating to use OME-Zarr in some cases, for example:
+
+* If you are working with small images, not planning to share them and your current tools already work well, then using OME-Zarr may not be necessary. Planned expansions to the specification (such as single-file Zarrs) will make it more convenient in these scenarios.
+
+* If you need specific conditions for which OME-Zarr support is not mature, you may need to use a different file format.
+  * Particularly, if your original file is lossy compressed, you will see a large increase in file size (about an order of magnitude) as the images are decompressed into OME-Zarr, since transferring lossy compressed tiles is not yet supported. This currently impacts most whole slide image (WSI) formats such as SVS, CZI, and NDPI, which are lossy JPEG compressed by default.
 
 ## Who is using OME-Zarr?
 
-These are *some* of the organizations (and their dataset pages) that are using OME-Zarr for their data.
+These are _some_ of the organizations (and their dataset pages) that are using OME-Zarr for their data.
 
-- [Allen Institute](https://bff.allencell.org/datasets)
-- biohub
-- [Broad Institute](https://broadinstitute.github.io/cellpainting-gallery/overview.html)
-- [EMBL - Image Data Resource (IDR)](https://idr.openmicroscopy.org/)
-- [Howard Hughes Medical Institute, Janelia (HHMI)](https://openorganelle.janelia.org/)
-- [Jackson Laboratory (JAX)](https://images.jax.org/)
-- ... [and more](./data/index)
+* [Allen Institute](https://bff.allencell.org/datasets)
+* biohub
+* [Broad Institute](https://broadinstitute.github.io/cellpainting-gallery/overview.html)
+* [EMBL - Image Data Resource (IDR)](https://idr.openmicroscopy.org/)
+* [Howard Hughes Medical Institute, Janelia (HHMI)](https://openorganelle.janelia.org/)
+* [Jackson Laboratory (JAX)](https://images.jax.org/)
+* ... [and more](./data/index)
 
 ## How do I use OME-Zarr?
 
 * Already have a Zarr?
-   * Check out the [tools section](./tools/index)!
+  * Check out the [tools section](./tools/index)!
 * Want to create a Zarr?
-   * Check out the [tools section](./tools/index)!
+  * Check out the [tools section](./tools/index)!
 * Want to see or download a Zarr?
-   * Check out the [data section](./data/index)!
+  * Check out the [data section](./data/index)!
+* Want to cite OME-Zarr/NGFF in your work?
+  * Check out the [publications section](./publications/index)!
 
 ## Have other questions?
 

--- a/resources/data/index.md
+++ b/resources/data/index.md
@@ -16,7 +16,7 @@ Resources curating OME-Zarr sample data, for demonstration and testing purposes.
 | BIA Samples | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://livingobjects.ebi.ac.uk/bioimaging-integrator-data/pages/idr_ngff_data.html" alt="BIA Samples logo" width="30" height="30">](https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/pages/omengff.html) | Sample OME-Zarr datasets from the BioImage Archive for testing |
 | Sanger Institute Samples | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://www.sanger.ac.uk/project/ome-zarr/" alt="Sanger Institute Samples logo" width="30" height="30">](https://www.sanger.ac.uk/project/ome-zarr/) | Datasets from the Sanger Institute that have been converted to OME-Zarr to test and encourage the file format |
 | SSBD samples | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://ssbd.riken.jp/ssbd-ome-ngff-samples" alt="SSBD samples logo" width="30" height="30">](https://ssbd.riken.jp/ssbd-ome-ngff-samples) | Sample OME-Zarr datasets from the Systems Science of Biological Dynamics database (SSBD) for testing and demonstration purposes |
-| OME 2024 NGFF challenge | [<img src="http://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME 2024 NGFF challenge logo" width="30" height="30">](https://ome.github.io/) | Close to 500 TB of data in the OME-Zarr 0.5 format |
+| OME 2024 NGFF challenge | [<img src="https://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME 2024 NGFF challenge logo" width="30" height="30">](https://ome.github.io/) | Close to 500 TB of data in the OME-Zarr 0.5 format |
 
 ## Data portals
 

--- a/resources/data/index.md
+++ b/resources/data/index.md
@@ -1,3 +1,4 @@
+(resources-data)=
 # Data Resources
 
 Looking for test data? [IDR Samples](https://idr.github.io/ome-ngff-samples/) aims at covering the different corners of the specification.

--- a/resources/ecosystem/index.md
+++ b/resources/ecosystem/index.md
@@ -1,8 +1,9 @@
+(resources-ecosystem)=
 # Ecosystem
 
 Workflows and data formats that adopt OME-Zarr and build upon it for extended capabilities and interoperabilitieswith additional systems.
 
-It extends the [tools](../tools/index.md) section by including projects that are not necessarily tools for viewing, writing, reading, converting, validating or processing OME-Zarr data, but that are still part of a ecosystem of projects with first-class, dedicated support for OME-Zarr.
+It extends the [tools](#resources-tools) section by including projects that are not necessarily tools for viewing, writing, reading, converting, validating or processing OME-Zarr data, but that are still part of a ecosystem of projects with first-class, dedicated support for OME-Zarr.
 
 It fits microscope acquisition software, analysis pipelines, standards and extensions, gallery-like displays, integrative workflows, and the like.
 

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -13,8 +13,8 @@ This feed is generated live from Europe PMC and will show the most recent public
 ```{raw} html
 <style>
   #pubfeed { max-width: 720px; }
-  #pubfeed-status { color: #888; font-size: 0.9em; }
-  #pubfeed ol { list-style: none; margin: 0; padding: 0; }
+  #pubfeed-status { color: #888; font-size: 0.85em; margin-bottom: 0.5em; }
+  #pubfeed ol { list-style: none; margin: 0; padding: 0; min-height: 18em; }
   #pubfeed li {
     padding: 0.75em 0;
     border-bottom: 1px solid rgba(128,128,128,0.2);
@@ -27,49 +27,60 @@ This feed is generated live from Europe PMC and will show the most recent public
     color: #666; font-size: 0.85em; margin-top: 0.15em;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
-  #pubfeed-more {
-    margin-top: 1em; padding: 0.5em 1.1em;
-    font-size: 0.9em; cursor: pointer;
-    background: transparent;
-    border: 1px solid rgba(128,128,128,0.4); border-radius: 6px;
-    color: inherit;
+  #pubfeed-nav {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 1em; margin-top: 1em;
   }
-  #pubfeed-more:hover { border-color: rgba(128,128,128,0.8); }
-  #pubfeed-more[hidden] { display: none; }
+  #pubfeed-nav button {
+    padding: 0.4em 1em; font-size: 0.9em; cursor: pointer;
+    background: transparent; color: inherit;
+    border: 1px solid rgba(128,128,128,0.4); border-radius: 6px;
+  }
+  #pubfeed-nav button:hover:not(:disabled) { border-color: rgba(128,128,128,0.8); }
+  #pubfeed-nav button:disabled { opacity: 0.35; cursor: default; }
+  #pubfeed-page { color: #888; font-size: 0.85em; }
 </style>
 
 <div id="pubfeed">
   <p id="pubfeed-status">Loading recent publications…</p>
   <ol id="pubfeed-list"></ol>
-  <button id="pubfeed-more" hidden>Load more</button>
+  <div id="pubfeed-nav" hidden>
+    <button id="pubfeed-prev">← Prev</button>
+    <span id="pubfeed-page"></span>
+    <button id="pubfeed-next">Next →</button>
+  </div>
 </div>
 
 <script>
 (async function () {
   const QUERY = '"NGFF" OR "OME-Zarr"';
-  const PAGE = 5;
+  const PAGE = 4;
   const BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest/search";
 
   const status = document.getElementById("pubfeed-status");
   const list = document.getElementById("pubfeed-list");
-  const moreBtn = document.getElementById("pubfeed-more");
+  const nav = document.getElementById("pubfeed-nav");
+  const prevBtn = document.getElementById("pubfeed-prev");
+  const nextBtn = document.getElementById("pubfeed-next");
+  const pageLabel = document.getElementById("pubfeed-page");
 
-  let cursor = "*";
+  const pages = [];          // cached results per page index
+  const cursors = ["*"];     // cursor to fetch page i
   let total = null;
-  let shown = 0;
+  let current = 0;
   let loading = false;
 
-  function urlFor(cursorMark) {
+  function urlFor(cursor) {
     return BASE +
       "?query=" + encodeURIComponent(QUERY) +
       "&format=json&resultType=lite" +
       "&pageSize=" + PAGE +
       "&sort=" + encodeURIComponent("P_PDATE_D desc") +
-      "&cursorMark=" + encodeURIComponent(cursorMark);
+      "&cursorMark=" + encodeURIComponent(cursor);
   }
 
-  function renderItems(results) {
-    const html = results.map(function (p) {
+  function render(results) {
+    list.innerHTML = results.map(function (p) {
       const link = p.doi
         ? "https://doi.org/" + p.doi
         : "https://europepmc.org/article/" + p.source + "/" + p.id;
@@ -85,39 +96,47 @@ This feed is generated live from Europe PMC and will show the most recent public
         '<div class="pub-meta">' + date + journal + '</div>' +
       '</li>';
     }).join("");
-    list.insertAdjacentHTML("beforeend", html);
   }
 
-  async function loadPage() {
+  function totalPages() {
+    return total ? Math.ceil(total / PAGE) : 1;
+  }
+
+  function updateNav() {
+    nav.hidden = false;
+    pageLabel.textContent = "Page " + (current + 1) + " of " + totalPages();
+    prevBtn.disabled = loading || current === 0;
+    nextBtn.disabled = loading || current >= totalPages() - 1;
+  }
+
+  async function show(i) {
     if (loading) return;
-    loading = true;
-    moreBtn.disabled = true;
+    if (pages[i]) { current = i; render(pages[i]); updateNav(); return; }
+
+    loading = true; updateNav();
     try {
-      const r = await fetch(urlFor(cursor));
+      const r = await fetch(urlFor(cursors[i]));
       const j = await r.json();
       const results = j.resultList?.result || [];
       if (total === null) total = j.hitCount ?? results.length;
-      renderItems(results);
-      shown += results.length;
-
-      // Advance cursor; stop if it didn't move or we've shown everything.
-      const next = j.nextCursorMark;
-      const done = !next || next === cursor || shown >= total;
-      cursor = next || cursor;
-
-      status.textContent = shown + " of " + total + " publications";
-      moreBtn.hidden = done;
+      pages[i] = results;
+      if (j.nextCursorMark) cursors[i + 1] = j.nextCursorMark;
+      current = i;
+      status.textContent = total + " publications";
+      render(results);
     } catch (e) {
       status.textContent = "Could not load publications.";
       console.warn(e);
     } finally {
       loading = false;
-      moreBtn.disabled = false;
+      updateNav();
     }
   }
 
-  moreBtn.addEventListener("click", loadPage);
-  loadPage();
+  prevBtn.addEventListener("click", function () { if (current > 0) show(current - 1); });
+  nextBtn.addEventListener("click", function () { show(current + 1); });
+
+  show(0);
 })();
 </script>
 ```

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -8,8 +8,6 @@ Core publications on NGFF and OME-Zarr. If you plan to cite OME-Zarr in your wor
 - [OME-Zarr: a cloud-optimized bioimaging file format with international community support](https://link.springer.com/article/10.1007/s00418-023-02209-1) 10th July 2023
 - [2024 OME-NGFF workflows hackathon Preprint](https://osf.io/preprints/biohackrxiv/5uhwz_v2) 13 March 2025
 
-For more details on OME-Zarr, see the [home page](#home-page).
-
 ## Recent publications mentioning NGFF or OME-Zarr
 
 This feed is generated live from Europe PMC and will show the most recent publications that mention NGFF or OME-Zarr in the title, abstract, or keywords.

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -1,6 +1,123 @@
-Publications
-============
+# Publications
 
-* [OME-NGFF: a next-generation file format for expanding bioimaging data-access strategies](https://www.nature.com/articles/s41592-021-01326-w) 29th November 2021
-* [OME-Zarr: a cloud-optimized bioimaging file format with international community support](https://link.springer.com/article/10.1007/s00418-023-02209-1) 10th July 2023
-* [2024 OME-NGFF workflows hackathon Preprint](https://osf.io/preprints/biohackrxiv/5uhwz_v2) 13 March 2025
+Core publications on NGFF and OME-Zarr. If you plan to cite OME-Zarr in your work, please use one or more of the following references, as appropriate.
+
+- [OME-NGFF: a next-generation file format for expanding bioimaging data-access strategies](https://www.nature.com/articles/s41592-021-01326-w) 29th November 2021
+- [OME-Zarr: a cloud-optimized bioimaging file format with international community support](https://link.springer.com/article/10.1007/s00418-023-02209-1) 10th July 2023
+- [2024 OME-NGFF workflows hackathon Preprint](https://osf.io/preprints/biohackrxiv/5uhwz_v2) 13 March 2025
+
+## Recent publications mentioning NGFF or OME-Zarr
+
+This feed is generated live from Europe PMC and will show the most recent publications that mention NGFF or OME-Zarr in the title, abstract, or keywords.
+
+```{raw} html
+<style>
+  #pubfeed { max-width: 720px; }
+  #pubfeed-status { color: #888; font-size: 0.9em; }
+  #pubfeed ol { list-style: none; margin: 0; padding: 0; }
+  #pubfeed li {
+    padding: 0.75em 0;
+    border-bottom: 1px solid rgba(128,128,128,0.2);
+  }
+  #pubfeed li:first-child { padding-top: 0; }
+  #pubfeed .pub-title { font-weight: 600; text-decoration: none; line-height: 1.4; }
+  #pubfeed .pub-title:hover { text-decoration: underline; }
+  #pubfeed .pub-meta { color: #888; font-size: 0.85em; margin-top: 0.25em; }
+  #pubfeed .pub-authors {
+    color: #666; font-size: 0.85em; margin-top: 0.15em;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  #pubfeed-more {
+    margin-top: 1em; padding: 0.5em 1.1em;
+    font-size: 0.9em; cursor: pointer;
+    background: transparent;
+    border: 1px solid rgba(128,128,128,0.4); border-radius: 6px;
+    color: inherit;
+  }
+  #pubfeed-more:hover { border-color: rgba(128,128,128,0.8); }
+  #pubfeed-more[hidden] { display: none; }
+</style>
+
+<div id="pubfeed">
+  <p id="pubfeed-status">Loading recent publications…</p>
+  <ol id="pubfeed-list"></ol>
+  <button id="pubfeed-more" hidden>Load more</button>
+</div>
+
+<script>
+(async function () {
+  const QUERY = '"NGFF" OR "OME-Zarr"';
+  const PAGE = 5;
+  const BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest/search";
+
+  const status = document.getElementById("pubfeed-status");
+  const list = document.getElementById("pubfeed-list");
+  const moreBtn = document.getElementById("pubfeed-more");
+
+  let cursor = "*";
+  let total = null;
+  let shown = 0;
+  let loading = false;
+
+  function urlFor(cursorMark) {
+    return BASE +
+      "?query=" + encodeURIComponent(QUERY) +
+      "&format=json&resultType=lite" +
+      "&pageSize=" + PAGE +
+      "&sort=" + encodeURIComponent("P_PDATE_D desc") +
+      "&cursorMark=" + encodeURIComponent(cursorMark);
+  }
+
+  function renderItems(results) {
+    const html = results.map(function (p) {
+      const link = p.doi
+        ? "https://doi.org/" + p.doi
+        : "https://europepmc.org/article/" + p.source + "/" + p.id;
+      const authors = (p.authorString || "").length > 90
+        ? p.authorString.slice(0, 90).replace(/,?\s*$/, "") + "…"
+        : (p.authorString || "");
+      const journal = p.journalTitle ? " · " + p.journalTitle : "";
+      const date = p.firstPublicationDate || p.pubYear || "";
+      return '<li>' +
+        '<a class="pub-title" href="' + link + '" target="_blank" rel="noopener">' +
+          (p.title || "Untitled") + '</a>' +
+        (authors ? '<div class="pub-authors">' + authors + '</div>' : '') +
+        '<div class="pub-meta">' + date + journal + '</div>' +
+      '</li>';
+    }).join("");
+    list.insertAdjacentHTML("beforeend", html);
+  }
+
+  async function loadPage() {
+    if (loading) return;
+    loading = true;
+    moreBtn.disabled = true;
+    try {
+      const r = await fetch(urlFor(cursor));
+      const j = await r.json();
+      const results = j.resultList?.result || [];
+      if (total === null) total = j.hitCount ?? results.length;
+      renderItems(results);
+      shown += results.length;
+
+      // Advance cursor; stop if it didn't move or we've shown everything.
+      const next = j.nextCursorMark;
+      const done = !next || next === cursor || shown >= total;
+      cursor = next || cursor;
+
+      status.textContent = shown + " of " + total + " publications";
+      moreBtn.hidden = done;
+    } catch (e) {
+      status.textContent = "Could not load publications.";
+      console.warn(e);
+    } finally {
+      loading = false;
+      moreBtn.disabled = false;
+    }
+  }
+
+  moreBtn.addEventListener("click", loadPage);
+  loadPage();
+})();
+</script>
+```

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -1,4 +1,5 @@
 (resources-publications)=
+
 # Publications
 
 Core publications on NGFF and OME-Zarr. If you plan to cite OME-Zarr in your work, please use one or more of the following references, as appropriate.
@@ -7,20 +8,31 @@ Core publications on NGFF and OME-Zarr. If you plan to cite OME-Zarr in your wor
 - [OME-Zarr: a cloud-optimized bioimaging file format with international community support](https://link.springer.com/article/10.1007/s00418-023-02209-1) 10th July 2023
 - [2024 OME-NGFF workflows hackathon Preprint](https://osf.io/preprints/biohackrxiv/5uhwz_v2) 13 March 2025
 
+For more details on OME-Zarr, see the [home page](#home-page).
+
 ## Recent publications mentioning NGFF or OME-Zarr
 
 This feed is generated live from Europe PMC and will show the most recent publications that mention NGFF or OME-Zarr in the title, abstract, or keywords.
 
 ```{raw} html
 <style>
-  #pubfeed { max-width: 720px; }
+  #pubfeed { max-width: 720px; margin-bottom: 2em; }
   #pubfeed-status { color: #888; font-size: 0.85em; margin-bottom: 0.5em; }
-  #pubfeed ol { list-style: none; margin: 0; padding: 0; min-height: 18em; }
+  #pubfeed-scroll {
+    max-height: 30em;
+    overflow-y: auto;
+    border: 1px solid rgba(128,128,128,0.25);
+    border-radius: 8px;
+    padding: 0 1em;
+    /* fade the top/bottom edges so it reads as scrollable */
+    -webkit-overflow-scrolling: touch;
+  }
+  #pubfeed ol { list-style: none; margin: 0; padding: 0; }
   #pubfeed li {
     padding: 0.75em 0;
     border-bottom: 1px solid rgba(128,128,128,0.2);
   }
-  #pubfeed li:first-child { padding-top: 0; }
+  #pubfeed li:last-child { border-bottom: none; }
   #pubfeed .pub-title { font-weight: 600; text-decoration: none; line-height: 1.4; }
   #pubfeed .pub-title:hover { text-decoration: underline; }
   #pubfeed .pub-meta { color: #888; font-size: 0.85em; margin-top: 0.25em; }
@@ -28,60 +40,46 @@ This feed is generated live from Europe PMC and will show the most recent public
     color: #666; font-size: 0.85em; margin-top: 0.15em;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
-  #pubfeed-nav {
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 1em; margin-top: 1em;
-  }
-  #pubfeed-nav button {
-    padding: 0.4em 1em; font-size: 0.9em; cursor: pointer;
-    background: transparent; color: inherit;
-    border: 1px solid rgba(128,128,128,0.4); border-radius: 6px;
-  }
-  #pubfeed-nav button:hover:not(:disabled) { border-color: rgba(128,128,128,0.8); }
-  #pubfeed-nav button:disabled { opacity: 0.35; cursor: default; }
-  #pubfeed-page { color: #888; font-size: 0.85em; }
+  #pubfeed-sentinel { height: 1px; }
 </style>
 
 <div id="pubfeed">
   <p id="pubfeed-status">Loading recent publications…</p>
-  <ol id="pubfeed-list"></ol>
-  <div id="pubfeed-nav" hidden>
-    <button id="pubfeed-prev">← Prev</button>
-    <span id="pubfeed-page"></span>
-    <button id="pubfeed-next">Next →</button>
+  <div id="pubfeed-scroll" hidden>
+    <ol id="pubfeed-list"></ol>
+    <div id="pubfeed-sentinel"></div>
   </div>
 </div>
 
 <script>
 (async function () {
   const QUERY = '"NGFF" OR "OME-Zarr"';
-  const PAGE = 4;
+  const PAGE = 25;
   const BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest/search";
 
   const status = document.getElementById("pubfeed-status");
+  const scrollBox = document.getElementById("pubfeed-scroll");
   const list = document.getElementById("pubfeed-list");
-  const nav = document.getElementById("pubfeed-nav");
-  const prevBtn = document.getElementById("pubfeed-prev");
-  const nextBtn = document.getElementById("pubfeed-next");
-  const pageLabel = document.getElementById("pubfeed-page");
+  const sentinel = document.getElementById("pubfeed-sentinel");
 
-  const pages = [];          // cached results per page index
-  const cursors = ["*"];     // cursor to fetch page i
+  let cursor = "*";
+  let nextCursor = null;
   let total = null;
-  let current = 0;
+  let loaded = 0;
   let loading = false;
+  let done = false;
 
-  function urlFor(cursor) {
+  function urlFor(c) {
     return BASE +
       "?query=" + encodeURIComponent(QUERY) +
       "&format=json&resultType=lite" +
       "&pageSize=" + PAGE +
       "&sort=" + encodeURIComponent("P_PDATE_D desc") +
-      "&cursorMark=" + encodeURIComponent(cursor);
+      "&cursorMark=" + encodeURIComponent(c);
   }
 
-  function render(results) {
-    list.innerHTML = results.map(function (p) {
+  function rowsFor(results) {
+    return results.map(function (p) {
       const link = p.doi
         ? "https://doi.org/" + p.doi
         : "https://europepmc.org/article/" + p.source + "/" + p.id;
@@ -99,45 +97,44 @@ This feed is generated live from Europe PMC and will show the most recent public
     }).join("");
   }
 
-  function totalPages() {
-    return total ? Math.ceil(total / PAGE) : 1;
-  }
-
-  function updateNav() {
-    nav.hidden = false;
-    pageLabel.textContent = "Page " + (current + 1) + " of " + totalPages();
-    prevBtn.disabled = loading || current === 0;
-    nextBtn.disabled = loading || current >= totalPages() - 1;
-  }
-
-  async function show(i) {
-    if (loading) return;
-    if (pages[i]) { current = i; render(pages[i]); updateNav(); return; }
-
-    loading = true; updateNav();
+  async function loadMore() {
+    if (loading || done) return;
+    loading = true;
     try {
-      const r = await fetch(urlFor(cursors[i]));
+      const r = await fetch(urlFor(cursor));
       const j = await r.json();
       const results = j.resultList?.result || [];
       if (total === null) total = j.hitCount ?? results.length;
-      pages[i] = results;
-      if (j.nextCursorMark) cursors[i + 1] = j.nextCursorMark;
-      current = i;
-      status.textContent = total + " publications";
-      render(results);
+
+      list.insertAdjacentHTML("beforeend", rowsFor(results));
+      loaded += results.length;
+
+      nextCursor = j.nextCursorMark || null;
+      // Europe PMC returns the same cursor back when exhausted.
+      if (!nextCursor || nextCursor === cursor || results.length === 0 || loaded >= total) {
+        done = true;
+      } else {
+        cursor = nextCursor;
+      }
+
+      scrollBox.hidden = false;
+      status.textContent = loaded + " of " + total + " publications";
     } catch (e) {
       status.textContent = "Could not load publications.";
       console.warn(e);
+      done = true;
     } finally {
       loading = false;
-      updateNav();
     }
   }
 
-  prevBtn.addEventListener("click", function () { if (current > 0) show(current - 1); });
-  nextBtn.addEventListener("click", function () { show(current + 1); });
+  // Infinite scroll: load the next batch when the sentinel scrolls into view.
+  const io = new IntersectionObserver(function (entries) {
+    if (entries.some(function (e) { return e.isIntersecting; })) loadMore();
+  }, { root: scrollBox, rootMargin: "200px" });
+  io.observe(sentinel);
 
-  show(0);
+  await loadMore();
 })();
 </script>
 ```

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -1,3 +1,4 @@
+(resources-publications)=
 # Publications
 
 Core publications on NGFF and OME-Zarr. If you plan to cite OME-Zarr in your work, please use one or more of the following references, as appropriate.

--- a/resources/rfc-status-codes/index.md
+++ b/resources/rfc-status-codes/index.md
@@ -1,18 +1,13 @@
-RFC status codes
-============
+# RFC status codes
 
-
-[RFC 1](../../rfc/1) defined a Request for Comments process for the NGFF community, which is used to drive changes. The text listed a set of codes used to define how a change progresses from an idea to actual adoption.
-
+[RFC 1](#rfc-1) defined a Request for Comments process for the NGFF community, which is used to drive changes. The text listed a set of codes used to define how a change progresses from an idea to actual adoption.
 
 ![State diagram of the RFC process](../../rfc/1/diagram.png)
 
-This resource is a (non-normative) table describing the different codes used in that specification that outline the states of the RFCs. It is _not_ a full description of the RFC process. 
+This resource is a (non-normative) table describing the different codes used in that specification that outline the states of the RFCs. It is _not_ a full description of the RFC process.
 The status codes indicating ends of an RFC process are outlined in **bold**.
 
-Wait times provide a sense on how fast the process is expected to move to the next phase. The actual time may vary in practice, given factors such as the time of the year and current capacity. 
-
-
+Wait times provide a sense on how fast the process is expected to move to the next phase. The actual time may vary in practice, given factors such as the time of the year and current capacity.
 
 | Phase | Code   | Description                                                                                         | Wait time       | Action by         |
 | ----- | ------ | --------------------------------------------------------------------------------------------------- | --------------- | ----------------- |
@@ -26,7 +21,7 @@ Wait times provide a sense on how fast the process is expected to move to the ne
 | RFC   | R2     | REVIEWERS submit REVIEWS with recommendations as new PRs.                                           | NA              | REVIEWER + EDITOR |
 | RFC   | R3     | EDITORS merge REVIEWS and send to AUTHOR for RESPONSE                                               | NA              | AUTHOR + EDITOR   |
 | RFC   | R4     | AUTHORS prepare RESPONSE and changes to RFC                                                         | NA              | AUTHOR            |
-| RFC   | R5     | EDITORS merge RESPONSE and changes to RFC, contacts  REVIEWERS                                      | 2 weeks         | REVIEWER + EDITOR |
+| RFC   | R5     | EDITORS merge RESPONSE and changes to RFC, contacts REVIEWERS                                       | 2 weeks         | REVIEWER + EDITOR |
 | RFC   | R6     | REVIEWERS approve?                                                                                  | NA              | REVIEWER          |
 | RFC   | R7     | If no, EDITORS approve?                                                                             | NA              | EDITOR            |
 | RFC   | R8     | If changes necessary, AUTHORS prepare changes to RFC and/or RESPONSE. If they are major, back to R1 | NA              | AUTHOR            |

--- a/resources/rfc-status-codes/index.md
+++ b/resources/rfc-status-codes/index.md
@@ -1,13 +1,18 @@
-# RFC status codes
+RFC status codes
+============
 
-[RFC 1](#rfc-1) defined a Request for Comments process for the NGFF community, which is used to drive changes. The text listed a set of codes used to define how a change progresses from an idea to actual adoption.
+
+[RFC 1](#rfcs:rfc1) defined a Request for Comments process for the NGFF community, which is used to drive changes. The text listed a set of codes used to define how a change progresses from an idea to actual adoption.
+
 
 ![State diagram of the RFC process](../../rfc/1/diagram.png)
 
-This resource is a (non-normative) table describing the different codes used in that specification that outline the states of the RFCs. It is _not_ a full description of the RFC process.
+This resource is a (non-normative) table describing the different codes used in that specification that outline the states of the RFCs. It is _not_ a full description of the RFC process. 
 The status codes indicating ends of an RFC process are outlined in **bold**.
 
-Wait times provide a sense on how fast the process is expected to move to the next phase. The actual time may vary in practice, given factors such as the time of the year and current capacity.
+Wait times provide a sense on how fast the process is expected to move to the next phase. The actual time may vary in practice, given factors such as the time of the year and current capacity. 
+
+
 
 | Phase | Code   | Description                                                                                         | Wait time       | Action by         |
 | ----- | ------ | --------------------------------------------------------------------------------------------------- | --------------- | ----------------- |
@@ -21,7 +26,7 @@ Wait times provide a sense on how fast the process is expected to move to the ne
 | RFC   | R2     | REVIEWERS submit REVIEWS with recommendations as new PRs.                                           | NA              | REVIEWER + EDITOR |
 | RFC   | R3     | EDITORS merge REVIEWS and send to AUTHOR for RESPONSE                                               | NA              | AUTHOR + EDITOR   |
 | RFC   | R4     | AUTHORS prepare RESPONSE and changes to RFC                                                         | NA              | AUTHOR            |
-| RFC   | R5     | EDITORS merge RESPONSE and changes to RFC, contacts REVIEWERS                                       | 2 weeks         | REVIEWER + EDITOR |
+| RFC   | R5     | EDITORS merge RESPONSE and changes to RFC, contacts  REVIEWERS                                      | 2 weeks         | REVIEWER + EDITOR |
 | RFC   | R6     | REVIEWERS approve?                                                                                  | NA              | REVIEWER          |
 | RFC   | R7     | If no, EDITORS approve?                                                                             | NA              | EDITOR            |
 | RFC   | R8     | If changes necessary, AUTHORS prepare changes to RFC and/or RESPONSE. If they are major, back to R1 | NA              | AUTHOR            |

--- a/resources/tools/index.md
+++ b/resources/tools/index.md
@@ -1,3 +1,4 @@
+(resources-tools)=
 # Tools
 
 A list of tools and libraries with OME-Zarr support. These are developed by various members of the NGFF community. If you think your tool/library should be listed here, please [open a pull request](https://github.com/ome/ngff).
@@ -44,7 +45,7 @@ Want to view a Zarr? Use one of these.
 | Odon | [<img src="https://github.githubassets.com/favicons/favicon.svg" alt="Odon logo" width="30" height="30">](https://github.com/alexcoulton/odon) | A spatial proteomics OME-Zarr viewer built in Rust.|
 | QuPath  | [<img src="https://avatars.githubusercontent.com/u/21292410?s=200&v=4" alt="QuPath logo" width='30' height='30'>](https://github.com/qupath/qupath) | Open source software for digital pathology image analysis |
 | syGlass | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://www.syglass.io/" alt="syGlass logo" width="30" height="30">](https://www.syglass.io/) | A VR desktop application for visualizing and segmenting 3D image data, with OME-Zarr streaming support. |
-| Viv (Avivator, Vizarr, Vitessce, ...) | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://vitessce.io/" alt="Viv logo" width="30" height="30">](https://github.com/hms-dbmi/viv) | A toolkit for interactive visualization of high-resolution, multiplexed bioimaging datasets. The viv toolkit is used by the [Avivator](https://avivator.gehlenborglab.org), [Vizarr](https://github.com/hms-dbmi/vizarr) and [Vitessce](http://vitessce.io) image viewers, among others |
+| Viv (Avivator, Vizarr, Vitessce, ...) | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://vitessce.io/" alt="Viv logo" width="30" height="30">](https://github.com/hms-dbmi/viv) | A toolkit for interactive visualization of high-resolution, multiplexed bioimaging datasets. The viv toolkit is used by the [Avivator](https://avivator.gehlenborglab.org), [Vizarr](https://github.com/hms-dbmi/vizarr) and [Vitessce](https://vitessce.io) image viewers, among others |
 | Vol-E | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fwww.allencell.org%2Fpathtrace-rendering.html" alt="Vol-E logo" width="30" height="30">](https://vole.allencell.org/) | A browser-based volume viewer |
 | WEBKNOSSOS | [<img src="https://www.google.com/s2/favicons?sz=256&domain_url=https://home.webknossos.org/" alt="WEBKNOSSOS logo" width="30" height="30">](https://home.webknossos.org/) | An open-source tool for annotating and exploring large 3D image datasets |
 
@@ -107,7 +108,7 @@ Want to validate a Zarr? Use one of these.
 
 | Name    | Link | Description |
 | -------- | ------- | ------- |
-| ome-ngff-validator | [<img src="http://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME NGFF Validator logo" width="30" height="30">](https://ome.github.io/ome-ngff-validator/) | Web page for validating OME-Zarr files. |
+| ome-ngff-validator | [<img src="https://www.openmicroscopy.org/img/logos/ome-logomark.svg" alt="OME NGFF Validator logo" width="30" height="30">](https://ome.github.io/ome-ngff-validator/) | Web page for validating OME-Zarr files. |
 | ome-zarr-models | [![image](https://github.githubassets.com/favicons/favicon.svg)](https://github.com/ome-zarr-models/ome-zarr-models-py) | Python package and command line interface that can validate OME-Zarr files |
 | yaozarrs | [![image](https://github.githubassets.com/favicons/favicon.svg)](https://github.com/imaging-formats/yaozarrs) | Bottom-up python library with models and CLI for creating & validating OME-Zarr groups and documents with optional extras for array-backend-agnostic I/O |
 

--- a/rfc/1/index.md
+++ b/rfc/1/index.md
@@ -1,6 +1,8 @@
 RFC-1: RFC Process
 ==================
 
+(rfcs:rfc1)=
+
 Definition of the NGFF “Request for Comment” (RFC) process
 
 ```{toctree}

--- a/rfc/1/index.md
+++ b/rfc/1/index.md
@@ -238,6 +238,7 @@ right direction. **Reviewers** should strive to provide feedback which informs *
 
 **Commenters** are other members of the community who, though not contacted as **Reviewers**, have provided feedback that they would like added to the official record of the RFC.
 
+(rfc1-implementation)=
 ## Implementation
 
 The RFC process can be represented as a state diagram with the various stakeholders responsible for forward motion.
@@ -322,7 +323,8 @@ to the **Editors**, either via a public PR adding the review in markdown to the
 RFC's subdirectory or by emailing the **Editors** directly. (This latter course
 should only be used when necessary.)
 
-(rfc-recommendations)= Possible recommendations from **Reviewers** in ascending order of support are:
+(rfc-recommendations)= 
+Possible recommendations from **Reviewers** in ascending order of support are:
 
 * “Reject” suggests that a **Reviewer** considers there to be no merit to an
   RFC. This should be a last recourse. Instead, suggestions in a “Major
@@ -367,7 +369,8 @@ contact **Reviewers** to see if their recommendations have changed.
 
 > 🕑 Authors responses to Reviewers should be returned to the Editors in less than two weeks.
 
-(anchor-rebuttal-r6)= This brings a critical, and possibly iterative, decision point (R6).  If all **Reviewers** `approve` and there are no further changes needed, the RFC can progress to S1 as soon as there are two in-progress implementations. If the **Reviewers** do _not_ approve, then the **Editors** will make one of three decisions (R7):
+(anchor-rebuttal-r6)= 
+This brings a critical, and possibly iterative, decision point (R6).  If all **Reviewers** `approve` and there are no further changes needed, the RFC can progress to S1 as soon as there are two in-progress implementations. If the **Reviewers** do _not_ approve, then the **Editors** will make one of three decisions (R7):
 
 * The **Editors** MAY provide **Authors** a list of necessary changes. These will be based on the **Reviewers** suggestions but possibly modified, e.g., to remove contradictions.
 * The **Editors** MAY decide that the RFC is to be closed (R9). This is the decision that SHOULD be chosen if there is a unanimous `Reject` recommendation. The **Authors** MAY then decide to re-draft a new RFC (D2).

--- a/rfc/1/templates/review_template.md
+++ b/rfc/1/templates/review_template.md
@@ -1,3 +1,4 @@
+(rfc1-review-template)=
 # Review Template
 
 Replace the title above of this file with “RFC-NUM: Review NUM”

--- a/rfc/3/comments/3/index.md
+++ b/rfc/3/comments/3/index.md
@@ -1,5 +1,7 @@
 # RFC-3: Comment 3
 
+(rfcs:rfc3:comment3)=
+
 | **Role** | Name | GitHub Handle | Institution | 
 |----------|------|---------------|-------------|
 | **Author** | [Cornelia Wetzker](https://orcid.org/0000-0002-8367-5163) | [cwetzker](https://github.com/cwetzker) | TU Dresden | 

--- a/rfc/3/versions/2026-07-17/index.md
+++ b/rfc/3/versions/2026-07-17/index.md
@@ -86,19 +86,19 @@ This RFC is currently in RFC state `R1` (send for review).
     - [btbest](https://github.com/btbest)
     -
     - 2026-02-02
-    - [Comment](./comments/1/index)
+    - [Comment](#rfcs:rfc3:comment1)
 *   - Commenter
     - Chris Barnes
     - [clbarnes](https://github.com/clbarnes)
     - German BioImaging
     - 2026-02-05
-    - [Comment](./comments/2/index)
+    - [Comment](#rfcs:rfc3:comment2)
 *   - Commenter
     - Cornelia Wetzker
     - [cwetzker](https://github.com/cwetzker)
     - Technische Universität Dresden
     - 2026-03-19
-    - [Comment](./comments/3/index)
+    - [Comment](#rfcs:rfc3:comment3)
 ```
 
 ## Overview
@@ -109,7 +109,7 @@ conversion of proprietary datasets, usage by microscope vendors[^1], and usage
 by novel microscopy modalities[^2].
 
 This RFC removes these restrictions, opening NGFF to many more users within its
-target domain (and beyond). Because it *only* removes restrictions, existing
+target domain (and beyond). Because it _only_ removes restrictions, existing
 valid OME-Zarr datasets will remain valid after implementation of this
 proposal.
 
@@ -144,7 +144,6 @@ and,
 >   (`yx`) and images are stacked along the other (anisotropic) axis (`z`), the
 >   spatial axes SHOULD be ordered as `zyx`.
 
-
 and,
 
 > - Every Zarr array referred to by a `path` MUST have the same number of
@@ -158,9 +157,9 @@ hamper the adoption of OME-Zarr as an acquisition-time format due to
 performance concerns: many acquisitions happen in TZCYX order (all channels are
 acquired together for each z-slice), which violates the "axes must be ordered
 by type" requirement. In such cases, scientists must first acquire their data
-and *then* transpose it — an expensive proposition for large datasets. (Note:
+and _then_ transpose it — an expensive proposition for large datasets. (Note:
 Admittedly, Zarr transpose codecs, as well as the mapAxis transformation from
-RFC-5, already offer solutions to this problem. However, the *simplest*
+RFC-5, already offer solutions to this problem. However, the _simplest_
 solution of flexible array ordering with default codecs and only scale and
 translation transforms is only open after this RFC.)
 
@@ -195,7 +194,7 @@ fluorophore decay lifetime can be used to get more information about the
 sample, for example by separating fluorophores not only according to their
 emission spectra but also their lifetime. The decay measurement constitutes an
 additional time axis called `u` or `µ` and can result in a 6-dimensional
-dataset with axes `CTUZYX`. (See [comment 3](./comments/3/index), and [this
+dataset with axes `CTUZYX`. (See [comment 3](#rfcs:rfc3:comment3), and [this
 paper][flim-paper].)
 
 FLIM data currently cannot be represented in OME-Zarr, causing users to use
@@ -219,7 +218,7 @@ important part of data quality checks. Currently, this kind of microscopy data
 cannot be stored in OME-Zarr.
 
 Within the same workflow, the crystal orientation is usually encoded as three
-*Euler angles* or four *quaternion* components stored at each pixel position.
+_Euler angles_ or four _quaternion_ components stored at each pixel position.
 Although it's possible to use the "custom" axis for this purpose, a dedicated
 axis with a clear naming convention is more ergonomic for scientists.
 
@@ -241,17 +240,17 @@ to save these intermediate image products for later reprocessing.
 
 ### Overlapping labels
 
-OME-Zarr can represent not only raw images, but also *label images*, or
+OME-Zarr can represent not only raw images, but also _label images_, or
 segmentations. Traditionally, segmentations assigned a single integer value to
 each pixel in the source image. However, newer segmentation methods produce
-*coarse-to-fine* segmentations, with semantic meaning. For images spanning many
+_coarse-to-fine_ segmentations, with semantic meaning. For images spanning many
 scales, as produced by modern microscopes, we may want to segment tissues,
 cells within those tissues, and organelles within those cells. These three
 levels of segmentations can be stacked along a new "coarseness" axis.
 
-Similarly, new segmentation methods can produce *overlapping binary masks*. Due
-to the overlap, they *cannot* be stored as traditional integer masks (one value
-per pixel), but are typically instead stored as *n* boolean masks. For this
+Similarly, new segmentation methods can produce _overlapping binary masks_. Due
+to the overlap, they _cannot_ be stored as traditional integer masks (one value
+per pixel), but are typically instead stored as _n_ boolean masks. For this
 mask, an extra "instance" axis is needed in addition to the [TCZ]YX axes of a
 source image.
 
@@ -261,7 +260,7 @@ Downstream computational products are necessary for the analysis of microscopy
 data, and these should ideally be stored in formats compatible with the tooling
 used to work with the raw data. The format aims to be flexible enough to
 accommodate these products, such as segmentations (the `label-image` section),
-or the outputs of registrations (see [rfc-5](../5/index)).
+or the outputs of registrations (see [rfc-5](#rfcs:rfc5:version3)).
 
 Some outputs may naturally contain arbitrary dimensions, for example, a grid
 search of the parameter space for a denoising algorithm may contain an
@@ -290,7 +289,8 @@ After this specification change, tools may encounter OME-Zarr files that don't
 match the earlier expectations of containing a subset of the TCZYX axes. This
 proposal is agnostic as to what to do in those situations, and indeed the
 appropriate action depends on the tool, but some suggestions include:
-- fail with an informative error message. (i.e. *partial* implementations are
+
+- fail with an informative error message. (i.e. _partial_ implementations are
   OK, especially if well-documented.)
 - prompt the user about which axes to treat as spatial.
 - arbitrarily choose which axes to treat as spatial.
@@ -304,36 +304,31 @@ document, taking as base the current development version:
 > - The length of `axes` must be between 2 and 5 and MUST be equal to the
 >   dimensionality of the Zarr arrays storing the image data (see
 >   `datasets:path`).
->
 > - `axes` MUST contain 2 or 3 entries of `type:space`
->
 > - `axes` MAY contain one additional entry of `type:time`
->
 > - `axes` MAY contain one additional entry of `type:channel` or a null /
 >   custom type.
->
 > - `axes` entries MUST be ordered by `type` where the `time` axis must come
 >   first (if present), followed by the `channel` or custom axis (if present)
 >   and the axes of type `space`.
->
 > - If there are three spatial axes where two correspond to the image plane
 >   (`yx`) and images are stacked along the other (anisotropic) axis (`z`), the
 >   spatial axes SHOULD be ordered as `zyx`.
 
-2. The following lines are *added* to "multiscales metadata":
+2. The following lines are _added_ to "multiscales metadata":
 
 > 0. The length of the axis names MUST match the number of axes of the array.
-> 1. *If* a dataset contains exactly 2 spatial dimensions, those dimensions
+> 1. _If_ a dataset contains exactly 2 spatial dimensions, those dimensions
 >    SHOULD be named `y` and `x`, except where rule 4 applies.
-> 2. *If* a dataset contains exactly 3 spatial dimensions, those dimensions
+> 2. _If_ a dataset contains exactly 3 spatial dimensions, those dimensions
 >    SHOULD be named 'z', 'y', and 'x', except where rule 4 applies.
-> 3. *If* a dataset contains exactly 1 time dimension, it should be named `t`.
+> 3. _If_ a dataset contains exactly 1 time dimension, it should be named `t`.
 > 4. When image data axes map straightforwardly to axes with common names in
 >    the relevant field of practice, those axes SHOULD be named according to
 >    such conventions. For example, spatial frequency axes resulting from a
 >    Fourier transformation of `z', 'y', and 'x' SHOULD be named 'w', 'v', and
->    `u`, respectively. Similarly, a temporal frequency axis resulting from
->    a Fourier transformation of the `t` axis SHOULD be named `w` or `ω`.
+`u`, respectively. Similarly, a temporal frequency axis resulting from
+a Fourier transformation of the `t`axis SHOULD be named`w`or`ω`.
 > 5. Axis names MUST NOT be repeated within a dataset, and SHOULD NOT be
 >    different only by upper/lower-case. For example, the same dataset SHOULD
 >    NOT have both an `X` and an `x` axis.
@@ -370,7 +365,7 @@ the RFC.
 
 Developers of visualization libraries and software are concerned that this PR
 may result in a "wild west" of OME-Zarr datasets that have little in common,
-making it difficult for tools to decide *which* axes to display. More details
+making it difficult for tools to decide _which_ axes to display. More details
 about these concerns are developed below in the "Drawbacks" section.
 
 ## Backwards Compatibility
@@ -426,21 +421,21 @@ have assuaged most implementation concerns][recap comment].
 ## Performance
 
 The current OME-Zarr specification ensures arrays are stored in order TCZYX.
-With C-order array data, this ensures efficient access for *some* but not *all*
+With C-order array data, this ensures efficient access for _some_ but not _all_
 access patterns. By removing restrictions on axis orderings, a new class of
 "mistake" is possible, as someone could save an array in order XYTCZ, which
 would combine poorly with C-order arrays to view XY planes. However, it is
-arguable that Zarr chunking is in fact more important here — XYTCZ *could* be
+arguable that Zarr chunking is in fact more important here — XYTCZ _could_ be
 a perfectly cromulent axis ordering for XY planes if the Zarr chunk size was
 (1024, 1024, 1, 1, 1).
 
 Moreover, imposing a fixed axis ordering can incur performance penalties at
-*write* time (where performance is often critical) if the data is not already
+_write_ time (where performance is often critical) if the data is not already
 in the expected order.
 
 Therefore, this proposal argues that any performance implications are better
 addressed through good documentation and good defaults. Indeed, more flexible
-dimension ordering could *improve* performance in some scenarios, such as
+dimension ordering could _improve_ performance in some scenarios, such as
 "pixel drilling", that is, extracting the value of a single x/y position over
 time.
 
@@ -475,7 +470,6 @@ an informative error message (e.g. "The given dataset contains an unknown axis
 
 This RFC is placed in the public domain.
 
-
 [nat methods paper]: https://www.nature.com/articles/s41592-021-01326-w
 [ome-model]: https://github.com/ome/ngff/pull/239/files#r1609781780
 [ngff 0.4]: https://ngff.openmicroscopy.org/specifications/0.4/index.html
@@ -502,11 +496,12 @@ This RFC is placed in the public domain.
 [zulip-rfc-3-thread]: https://imagesc.zulipchat.com/#narrow/channel/328251-NGFF/topic/RFC-3.3A.20remove.20dimension.20restrictions/near/568178521
 
 [^1]: https://github.com/ome/ngff/pull/239#issuecomment-2122809286
+
 [^2]: https://github.com/ome/ngff/pull/239#issuecomment-2149119404
 
 ## Changelog
 
-| Date       | Description                  | Link                                                                         |
-| ---------- | ---------------------------- | ---------------------------------------------------------------------------- |
-| 2024-10-08 | RFC assigned and published   | [https://github.com/ome/ngff/pull/239](https://github.com/ome/ngff/pull/239) |
-| 2026-07-04 | Updated to address comments, elaborate on use cases, include specific changes to spec doc, and add test data   | [https://github.com/ome/ngff/pull/560](https://github.com/ome/ngff/pull/560) |
+| Date       | Description                                                                                                  | Link                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| 2024-10-08 | RFC assigned and published                                                                                   | [https://github.com/ome/ngff/pull/239](https://github.com/ome/ngff/pull/239) |
+| 2026-07-04 | Updated to address comments, elaborate on use cases, include specific changes to spec doc, and add test data | [https://github.com/ome/ngff/pull/560](https://github.com/ome/ngff/pull/560) |

--- a/specifications/index.md
+++ b/specifications/index.md
@@ -1,9 +1,8 @@
-Specifications
-==============
+# Specifications
 
 OME-Zarr files have standardized metadata (that is the OME portion of "OME-Zarr") - each new version of OME-Zarr files has its own specification. Those specifications are listed below.
 
-The current released version of the OME-Zarr specification is [0.5](0.5/ngff_spec/index.md).
+The current released version of the OME-Zarr specification is [0.5](0.5/index.md).
 
 ```{toctree}
 :maxdepth: 1


### PR DESCRIPTION
Adds a "last articles about OME-Zarr + NGFF" feed to the /publications page 

Also changes the first page to add clearer links + improving wording on when to use/not as the ecosystem evolves 