### PR TITLE
feat: serve dev schemas under their actual name

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -108,6 +108,15 @@ def build_served_html():
         if os.path.isdir(os.path.join("specifications", d))
     ]
 
+    # create a special folder for extra html for the latest schemas
+    # that refers to the development version of the specification
+    sys.path.insert(0, str(Path(__file__).parent))
+    from specifications.dev._version import __version__ as dev_version
+
+    os.makedirs(f"_html_extra/{dev_version}/schemas", exist_ok=True)
+    for schema in glob.glob(f"specifications/dev/**/*.schema", recursive=True):
+        shutil.copy2(schema, f"_html_extra/{dev_version}/schemas/")
+
     for version in versions:
 
         # copy schemas to _html_extra


### PR DESCRIPTION
Fixes #563 
Fixes https://github.com/ome/ngff-spec/issues/69

Small change to how the schemas are provided from the ngff page. In the current build, schemas are always served under a folder name that is derived from the name of the git submodule. For the dev versions, I see value in serving the (latest) schemas under both

- `https://ngff.openmicroscopy.org/dev/schemas/...`
- `https://ngff.openmicroscopy.org/0.9.dev17/schemas/...`

which would be possible through this PR.

*Edit*: I think this will also greatly reduce the number of warnings for the RTD build, since all the schema URLs will now correctly resolve to the ngff page, which is something @dstansby reported already a while ago (see https://github.com/ome/ngff-spec/issues/69). I thought it was a json-schema-forhumans-issue, but the problem is maybe that schema URLs could not be resolved correctly since they weren't served under their actual name.

cc @lubianat 