### PR TITLE
feat: serve schemas based on which tags exist on gh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.DS_Store
 **/__pycache__/*
 */index.html
+_tmp_ngff_spec/
 _build
 _html_extra
 .tox

--- a/conf.py
+++ b/conf.py
@@ -105,43 +105,38 @@ def build_served_html():
     
     # Create .htaccess to serve schemas inline (not download)
     os.makedirs("_html_extra", exist_ok=True)
-    htaccess_content = """<FilesMatch "\\.schema$">
-    Header set Content-Disposition "inline"
-</FilesMatch>
-"""
-    with open("_html_extra/.htaccess", "w") as f:
-        f.write(htaccess_content)
-    print(f"✅ Created .htaccess to serve schemas inline")
-    
+
     # Fetch GitHub tags and download schemas
-    try:
-        result = subprocess.check_output([
-            "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
-        ], text=True, timeout=10)
-        tags = [line.split()[1].replace("refs/tags/", "").rstrip("^{}") for line in result.strip().split("\n") if line]
-        for tag in sorted(set(tags)):
-            schema_dir = f"_html_extra/{tag}/schemas"
-            os.makedirs(schema_dir, exist_ok=True)
-            # Download schemas from GitHub raw for this tag
-            gh_url = f"https://github.com/ome/ngff-spec/archive/refs/tags/{tag}.tar.gz"
-            try:
-                import tempfile, tarfile
-                with tempfile.NamedTemporaryFile(delete=False) as tmp:
-                    subprocess.check_call(["curl", "-sL", gh_url, "-o", tmp.name])
-                    with tarfile.open(tmp.name) as tar:
-                        for member in tar.getmembers():
-                            if "/schemas/" in member.name and member.name.endswith(".schema"):
-                                # Extract just the filename, flatten into schema_dir
-                                target = os.path.join(schema_dir, os.path.basename(member.name))
-                                tar.extract(member, path=tempfile.gettempdir())
-                                src = os.path.join(tempfile.gettempdir(), member.name)
-                                shutil.copy2(src, target)
-                    os.unlink(tmp.name)
-                print(f"✅ Downloaded schemas for {tag}")
-            except Exception as e:
-                print(f"⚠️  Could not download schemas for {tag}: {e}")
-    except Exception:
-        pass
+    result = subprocess.check_output([
+        "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
+    ], text=True, timeout=10)
+    tags = [
+        line.split()[1].replace("refs/tags/", "").rstrip("^{}")
+        for line in result.strip().split("\n") if line
+        ]
+
+    # Clone repo once, checkout each tag (faster than per-tag tarball download)
+    repo_path = "_temp_ngff_spec"
+    if not os.path.exists(repo_path):
+        subprocess.check_call(["git", "clone", "https://github.com/ome/ngff-spec", repo_path])
+    
+    for tag in sorted(set(tags)):
+        schema_dir = f"_html_extra/{tag}/schemas"
+        os.makedirs(schema_dir, exist_ok=True)
+        try:
+            subprocess.check_call(["git", "-C", repo_path, "checkout", tag], 
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            src_schemas = glob.glob(os.path.join(repo_path, "**", "*.schema"), recursive=True)
+
+            if len(src_schemas) == 0:
+                print(f"⚠️  No schemas found for {tag}")
+                continue
+
+            for schema_file in src_schemas:
+                shutil.copy2(schema_file, schema_dir)
+            print(f"✅ Checked out schemas for {tag}")
+        except Exception as e:
+            print(f"⚠️  Could not checkout {tag}: {e}")
     
     # Build specifications from local submodules
     displayed_spec_versions = [
@@ -175,6 +170,13 @@ def build_served_html():
 
         subprocess.check_call([sys.executable, script])
         print("✅ Built rendered examples/schemas for version", version)
+
+        # copy schemas to _html_extra for served html
+        schema_files = glob.glob(f"specifications/{version}/**/*.schema", recursive=True)
+        for schema_file in schema_files:
+            dest_dir = os.path.join("_html_extra", version, "schemas")
+            os.makedirs(dest_dir, exist_ok=True)
+            shutil.copy2(schema_file, dest_dir)
 
         # build jupyter-book docs in specification submodules
         myst_file = glob.glob(f"specifications/{version}/**/myst.yml", recursive=True)[

--- a/conf.py
+++ b/conf.py
@@ -133,7 +133,9 @@ def build_served_html(clean_up=True):
                 continue
 
             for schema_file in src_schemas:
-                shutil.copy2(schema_file, schema_dir)
+                dest_file = os.path.join(schema_dir, os.path.basename(schema_file))
+                shutil.copy2(schema_file, dest_file)
+                shutil.copy2(schema_file, dest_file + '.json')  # dual format
             print(f"✅ Checked out schemas for {tag}")
         except Exception as e:
             print(f"⚠️  Could not checkout {tag}: {e}")
@@ -178,7 +180,9 @@ def build_served_html(clean_up=True):
         for schema_file in schema_files:
             dest_dir = os.path.join("_html_extra", version, "schemas")
             os.makedirs(dest_dir, exist_ok=True)
-            shutil.copy2(schema_file, dest_dir)
+            dest_file = os.path.join(dest_dir, os.path.basename(schema_file))
+            shutil.copy2(schema_file, dest_file)
+            shutil.copy2(schema_file, dest_file + '.json')  # ponytail: dual format
 
         # build jupyter-book docs in specification submodules
         myst_file = glob.glob(f"specifications/{version}/**/myst.yml", recursive=True)[

--- a/conf.py
+++ b/conf.py
@@ -93,7 +93,7 @@ html_extra_path = [
 ]
 
 
-def build_served_html():
+def build_served_html(clean_up=True):
     import glob
     import subprocess
     import sys
@@ -137,7 +137,9 @@ def build_served_html():
             print(f"✅ Checked out schemas for {tag}")
         except Exception as e:
             print(f"⚠️  Could not checkout {tag}: {e}")
-    
+    if clean_up:
+        shutil.rmtree(repo_path, ignore_errors=True)
+
     # Build specifications from local submodules
     displayed_spec_versions = [
         d

--- a/conf.py
+++ b/conf.py
@@ -103,15 +103,35 @@ def build_served_html():
 
     os.chdir(Path(__file__).parent)
     
-    # Create .htaccess to redirect all schema requests to GitHub
-    # ponytail: one rewrite rule handles all versions/files, avoids generating per-file stubs
-    os.makedirs("_html_extra", exist_ok=True)
-    htaccess_content = """RewriteEngine On
-RewriteRule ^([^/]+)/schemas/(.*)$ https://raw.githubusercontent.com/ome/ngff-spec/$1/schemas/$2 [R=301,L]
-"""
-    with open("_html_extra/.htaccess", "w") as f:
-        f.write(htaccess_content)
-    print(f"✅ Created .htaccess redirect for all schemas → GitHub raw")
+    # Fetch GitHub tags and download schemas
+    try:
+        result = subprocess.check_output([
+            "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
+        ], text=True, timeout=10)
+        tags = [line.split()[1].replace("refs/tags/", "").rstrip("^{}") for line in result.strip().split("\n") if line]
+        for tag in sorted(set(tags)):
+            schema_dir = f"_html_extra/{tag}/schemas"
+            os.makedirs(schema_dir, exist_ok=True)
+            # Download schemas from GitHub raw for this tag
+            gh_url = f"https://github.com/ome/ngff-spec/archive/refs/tags/{tag}.tar.gz"
+            try:
+                import tempfile, tarfile
+                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                    subprocess.check_call(["curl", "-sL", gh_url, "-o", tmp.name])
+                    with tarfile.open(tmp.name) as tar:
+                        for member in tar.getmembers():
+                            if "/schemas/" in member.name and member.name.endswith(".schema"):
+                                # Extract just the filename, flatten into schema_dir
+                                target = os.path.join(schema_dir, os.path.basename(member.name))
+                                tar.extract(member, path=tempfile.gettempdir())
+                                src = os.path.join(tempfile.gettempdir(), member.name)
+                                shutil.copy2(src, target)
+                    os.unlink(tmp.name)
+                print(f"✅ Downloaded schemas for {tag}")
+            except Exception as e:
+                print(f"⚠️  Could not download schemas for {tag}: {e}")
+    except Exception:
+        pass
     
     # Build specifications from local submodules
     displayed_spec_versions = [

--- a/conf.py
+++ b/conf.py
@@ -182,7 +182,7 @@ def build_served_html(clean_up=True):
             os.makedirs(dest_dir, exist_ok=True)
             dest_file = os.path.join(dest_dir, os.path.basename(schema_file))
             shutil.copy2(schema_file, dest_file)
-            shutil.copy2(schema_file, dest_file + '.json')  # ponytail: dual format
+            shutil.copy2(schema_file, dest_file + '.json')  # dual format (json + schema)
 
         # build jupyter-book docs in specification submodules
         myst_file = glob.glob(f"specifications/{version}/**/myst.yml", recursive=True)[

--- a/conf.py
+++ b/conf.py
@@ -105,6 +105,7 @@ def build_served_html():
     
     # Create .htaccess to redirect all schema requests to GitHub
     # ponytail: one rewrite rule handles all versions/files, avoids generating per-file stubs
+    os.makedirs("_html_extra", exist_ok=True)
     htaccess_content = """RewriteEngine On
 RewriteRule ^([^/]+)/schemas/(.*)$ https://raw.githubusercontent.com/ome/ngff-spec/$1/schemas/$2 [R=301,L]
 """

--- a/conf.py
+++ b/conf.py
@@ -103,19 +103,14 @@ def build_served_html():
 
     os.chdir(Path(__file__).parent)
     
-    # Fetch GitHub tags and create schema redirects
-    try:
-        result = subprocess.check_output([
-            "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
-        ], text=True, timeout=10)
-        tags = [line.split()[1].replace("refs/tags/", "").rstrip("^{}") for line in result.strip().split("\n") if line]
-        for tag in sorted(set(tags)):
-            os.makedirs(f"_html_extra/{tag}/schemas", exist_ok=True)
-            with open(f"_html_extra/{tag}/schemas/index.html", "w") as f:
-                f.write(f'<meta http-equiv="refresh" content="0;url=https://raw.githubusercontent.com/ome/ngff-spec/{tag}/schemas/">')
-            print(f"✅ Redirect schemas/{tag} → GitHub raw")
-    except Exception:
-        pass
+    # Create .htaccess to redirect all schema requests to GitHub
+    # ponytail: one rewrite rule handles all versions/files, avoids generating per-file stubs
+    htaccess_content = """RewriteEngine On
+RewriteRule ^([^/]+)/schemas/(.*)$ https://raw.githubusercontent.com/ome/ngff-spec/$1/schemas/$2 [R=301,L]
+"""
+    with open("_html_extra/.htaccess", "w") as f:
+        f.write(htaccess_content)
+    print(f"✅ Created .htaccess redirect for all schemas → GitHub raw")
     
     # Build specifications from local submodules
     displayed_spec_versions = [

--- a/conf.py
+++ b/conf.py
@@ -57,25 +57,6 @@ redirects = {
     "dev/": "../specifications/dev/index.html",
 }
 
-# Populate schema redirects from GitHub tags
-def _populate_schema_redirects():
-    import subprocess
-    result = subprocess.check_output([
-        "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
-    ], text=True, timeout=10)
-    # result looks like this
-    # e3d2f8ffbbcfb0e0906e901ec572f5c49b36328d        refs/tags/0.6.dev1
-    # da4606bf96d2829ad74b4dbaf6de5afb6b7a595a        refs/tags/0.6.dev2
-
-    tags = [
-        line.split()[1].replace("refs/tags/", "").rstrip("^{}")
-        for line in result.strip().split("\n") if line
-        ]
-    for tag in sorted(set(tags)):
-        redirects[f"{tag}/schemas/"] = f"https://raw.githubusercontent.com/ome/ngff-spec/{tag}/schemas/"
-
-_populate_schema_redirects()
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
@@ -121,6 +102,20 @@ def build_served_html():
     from pathlib import Path
 
     os.chdir(Path(__file__).parent)
+    
+    # Fetch GitHub tags and create schema redirects
+    try:
+        result = subprocess.check_output([
+            "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
+        ], text=True, timeout=10)
+        tags = [line.split()[1].replace("refs/tags/", "").rstrip("^{}") for line in result.strip().split("\n") if line]
+        for tag in sorted(set(tags)):
+            os.makedirs(f"_html_extra/{tag}/schemas", exist_ok=True)
+            with open(f"_html_extra/{tag}/schemas/index.html", "w") as f:
+                f.write(f'<meta http-equiv="refresh" content="0;url=https://raw.githubusercontent.com/ome/ngff-spec/{tag}/schemas/">')
+            print(f"✅ Redirect schemas/{tag} → GitHub raw")
+    except Exception:
+        pass
     
     # Build specifications from local submodules
     displayed_spec_versions = [

--- a/conf.py
+++ b/conf.py
@@ -103,6 +103,16 @@ def build_served_html():
 
     os.chdir(Path(__file__).parent)
     
+    # Create .htaccess to serve schemas inline (not download)
+    os.makedirs("_html_extra", exist_ok=True)
+    htaccess_content = """<FilesMatch "\\.schema$">
+    Header set Content-Disposition "inline"
+</FilesMatch>
+"""
+    with open("_html_extra/.htaccess", "w") as f:
+        f.write(htaccess_content)
+    print(f"✅ Created .htaccess to serve schemas inline")
+    
     # Fetch GitHub tags and download schemas
     try:
         result = subprocess.check_output([

--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,25 @@ redirects = {
     "dev/": "../specifications/dev/index.html",
 }
 
+# Populate schema redirects from GitHub tags
+def _populate_schema_redirects():
+    import subprocess
+    result = subprocess.check_output([
+        "git", "ls-remote", "--tags", "https://github.com/ome/ngff-spec"
+    ], text=True, timeout=10)
+    # result looks like this
+    # e3d2f8ffbbcfb0e0906e901ec572f5c49b36328d        refs/tags/0.6.dev1
+    # da4606bf96d2829ad74b4dbaf6de5afb6b7a595a        refs/tags/0.6.dev2
+
+    tags = [
+        line.split()[1].replace("refs/tags/", "").rstrip("^{}")
+        for line in result.strip().split("\n") if line
+        ]
+    for tag in sorted(set(tags)):
+        redirects[f"{tag}/schemas/"] = f"https://raw.githubusercontent.com/ome/ngff-spec/{tag}/schemas/"
+
+_populate_schema_redirects()
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
@@ -102,20 +121,15 @@ def build_served_html():
     from pathlib import Path
 
     os.chdir(Path(__file__).parent)
-    versions = [
+    
+    # Build specifications from local submodules
+    displayed_spec_versions = [
         d
         for d in os.listdir("specifications")
         if os.path.isdir(os.path.join("specifications", d))
     ]
 
-    for version in versions:
-
-        # copy schemas to _html_extra
-        os.makedirs(f"_html_extra/{version}/schemas", exist_ok=True)
-        schemas = glob.glob(f"specifications/{version}/**/*.schema", recursive=True)
-        for schema in schemas:
-            shutil.copy2(schema, f"_html_extra/{version}/schemas/")
-        print(f"✅ Copied schemas for version {version}")
+    for version in displayed_spec_versions:
 
         # find 'pre_build.py' in 'specifications' subdirectories
         script = glob.glob(f"specifications/{version}/**/pre_build.py", recursive=True)[


### PR DESCRIPTION
PR following #564 that solves the problem a bit more elegantly (I hope):

This PR changes the build process of the page so that the following happens on build:

- All tags on ome/ngff-spec are automatically retrieved with `git ls-remote --tags https://github.com/ome/ngff-spec`
- This gives a list of tagged versions on that repo (currently the ones [listed below](https://github.com/ome/ngff/pull/581#issuecomment-5450270176))
- Copy all the schemas over here and serve them under the respective tag as _.schema_ as well as _.schema.json_
- The schema publishing for the older versions (0.1...0.5 + dev) remains active as we still have the submodules in place here, from which we copy the schemas and serve them as well. Currently, schemas from the submodules **supersede the schemas from the tags**, but that's not a problem since none of the submodule'd schemas are from stagged version (i.e., 0.1...0.5 have not been tagged at ngff-spec)

This way, we are able to access the schemas of all past (we'd need to tag them) and present through the ngff page, _including the dev versions_. This also centralizes the tagging over at ngff-spec as a core mechanic to make schemas available through the ngff page.

To figure out next: If the 0.5 schema has changed, should it be published under 0.5 or under 0.5.X? which is a question we don't yet have answered.

cc @jni 