### PR TITLE
Update the Community page on NGFF

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -1,5 +1,12 @@
 # Community
 
+## OME NGFF Community Calendar
+
+<iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?src=14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com&ctz=local" style="border: 0" width="800" height="400" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
+
+Download the <a href="https://calendar.google.com/calendar/ical/14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com/public/basic.ics">.ics</a> file and add it to your calendar so won't miss any of our meetings!
+
+
 ## Community Calls
 Community Calls are quarterly meetings that feature updates and presentations on OME-Zarr specification work, tooling ecosystem, and use cases. **Everyone is welcome** to these calls - developers, users, and enthusiasts alike. Whether you have just heard about OME-NGFF and are curious to learn more or if you have been working with it every day, consider yourself invited.
 
@@ -24,13 +31,16 @@ Please see the [calendar](#ome-ngff-community-calendar) below for exact time to 
 
 ## Hackathons & Symposiums
 
-Hackathons have been hosted yearly by the BioVision Center in Zurich:
+Dedicated hackathons and workshops have been hosted yearly by the BioVision Center in Zurich:
 
 | Dates | Website | Outcomes |
 | ---- | ------- | -------- |
 | Nov 6-8, 2023 | [Next generation bioimage analysis workflows hackathon](https://www.biovisioncenter.uzh.ch/en/events/2023/hackathon_23.html)| [2023 image.sc post](https://forum.image.sc/t/outcomes-of-the-next-generation-bioimage-analysis-workflows-hackathon/88733)|
 | Nov 18-22, 2024 | [2024 OME-NGFF Workflows Hackathon](https://biovisioncenter.uzh.ch/en/events/2024/hackaton_november_2024.html)| [2024 Preprint](https://doi.org/10.37044/osf.io/5uhwz_v1)|
 | Nov 10-14, 2025 | [2025 OME-NGFF Workshop](https://www.biovisioncenter.uzh.ch/en/events/Upcoming-Events/2025-OME-NGFF-workshop.html)| |
+| Nov 2-6, 2026 | [2026 OME-Zarr Hackathons](https://biovisioncenter.notion.site/2026-ome-zarr-hackathon)| |
+
+
 
 ```{image} ../images/hackathons/IMG_7670.jpeg
 :width: 200px
@@ -42,11 +52,6 @@ Hackathons have been hosted yearly by the BioVision Center in Zurich:
 :width: 200px
 ```
 
-## OME NGFF Community Calendar
-
-<iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?src=14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com&ctz=local" style="border: 0" width="800" height="400" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
-
-Download the <a href="https://calendar.google.com/calendar/ical/14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com/public/basic.ics">.ics</a> file and add it to your calendar so won't miss any of our meetings!
 
 ## Contributors
 (community:contributors)=

--- a/community/index.md
+++ b/community/index.md
@@ -4,7 +4,7 @@
 
 <iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?src=14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com&ctz=local" style="border: 0; height: 400px; width:100%; max-width:800px;" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
 
-Download the <a href="https://calendar.google.com/calendar/ical/14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com/public/basic.ics">.ics</a> file and add it to your calendar so won't miss any of our meetings!
+Download the <a href="https://calendar.google.com/calendar/ical/14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com/public/basic.ics">.ics</a> file and add it to your calendar so you won't miss any of our meetings!
 You may also add it directly to your Google Calendar by clicking the "+" button in the bottom right corner.
 
 
@@ -15,8 +15,8 @@ We host Community Calls **quarterly at 9:00 CET and 17:00 CET**. The same agenda
 
 Community Calls are added to the above calendar and announced on [image.sc](https://forum.image.sc/tag/ngff-community-call):
 
-<div style="overflow:hidden; overflow-y:scroll; height:180px; width:100%; max-width:800px;;">
-<iframe frameborder="0" scrolling="no" width="800" height="500" src="https://forum.image.sc/embed/topics?tags=ngff-community-call">iframe not supported!</iframe>
+<div style="overflow-x:hidden; overflow-y:scroll; height:180px; width:100%; max-width:800px;">
+<iframe title="NGFF community call announcements" frameborder="0" scrolling="no" style="width:100%; height:500px;" src="https://forum.image.sc/embed/topics?tags=ngff-community-call">iframe not supported!</iframe>
 </div>
 
 
@@ -43,7 +43,7 @@ Dedicated hackathons and workshops have been hosted yearly by the BioVision Cent
 | Nov 6-8, 2023 | [Next generation bioimage analysis workflows hackathon](https://www.biovisioncenter.uzh.ch/en/events/2023/hackathon_23.html)| [2023 image.sc post](https://forum.image.sc/t/outcomes-of-the-next-generation-bioimage-analysis-workflows-hackathon/88733)|
 
 The OME Community Meeting is also a prime event to interact with the NGFF community.
-It is hosted yearly in different location around the world.
+It is hosted yearly in different locations around the world.
 
 | Dates  | Location | Resources |
 | ------ | ------- | -------- |

--- a/community/index.md
+++ b/community/index.md
@@ -2,9 +2,10 @@
 
 ## OME NGFF Community Calendar
 
-<iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?src=14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com&ctz=local" style="border: 0" width="800" height="400" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
+<iframe id="calendariframe" src="https://calendar.google.com/calendar/embed?src=14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com&ctz=local" style="border: 0; height: 400px; width:100%; max-width:800px;" frameborder="0" scrolling="no"></iframe> <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
 
 Download the <a href="https://calendar.google.com/calendar/ical/14c96687c3814f289f92de53b49bdfa7e5161d458ed1ab02d6a6c8a994522e10%40group.calendar.google.com/public/basic.ics">.ics</a> file and add it to your calendar so won't miss any of our meetings!
+You may also add it directly to your Google Calendar by clicking the "+" button in the bottom right corner.
 
 
 ## Community Calls
@@ -14,9 +15,10 @@ We host Community Calls **quarterly at 9:00 CET and 17:00 CET**. The same agenda
 
 Community Calls are added to the above calendar and announced on [image.sc](https://forum.image.sc/tag/ngff-community-call):
 
-<div style="overflow:hidden; overflow-y:scroll; height:180px; width:800px;">
+<div style="overflow:hidden; overflow-y:scroll; height:180px; width:100%; max-width:800px;;">
 <iframe frameborder="0" scrolling="no" width="800" height="500" src="https://forum.image.sc/embed/topics?tags=ngff-community-call">iframe not supported!</iframe>
 </div>
+
 
 ## Office Hours
 
@@ -27,7 +29,7 @@ APAC/AU/EU- and AMER/AU/EU-friendly times. We are happy to answer questions abou
 - how you can get involved in the community
 - ... and much more!
 
-Please see the [calendar](#ome-ngff-community-calendar) below for exact time to join at the [**Zoom link**](https://openmicroscopy-org.zoom.us/j/82526689042?pwd=ZIde7mcvZugQGmJ8Bm9piFo5Tzwdy1.1).
+Please see the [calendar](#ome-ngff-community-calendar) above for exact time to join at the [**Zoom link**](https://openmicroscopy-org.zoom.us/j/82526689042?pwd=ZIde7mcvZugQGmJ8Bm9piFo5Tzwdy1.1).
 
 ## Hackathons & Symposiums
 
@@ -35,11 +37,18 @@ Dedicated hackathons and workshops have been hosted yearly by the BioVision Cent
 
 | Dates | Website | Outcomes |
 | ---- | ------- | -------- |
-| Nov 6-8, 2023 | [Next generation bioimage analysis workflows hackathon](https://www.biovisioncenter.uzh.ch/en/events/2023/hackathon_23.html)| [2023 image.sc post](https://forum.image.sc/t/outcomes-of-the-next-generation-bioimage-analysis-workflows-hackathon/88733)|
-| Nov 18-22, 2024 | [2024 OME-NGFF Workflows Hackathon](https://biovisioncenter.uzh.ch/en/events/2024/hackaton_november_2024.html)| [2024 Preprint](https://doi.org/10.37044/osf.io/5uhwz_v1)|
+| Nov 2-6, 2026 | [2026 OME-Zarr Hackathon](https://biovisioncenter.notion.site/2026-ome-zarr-hackathon)| |
 | Nov 10-14, 2025 | [2025 OME-NGFF Workshop](https://www.biovisioncenter.uzh.ch/en/events/Upcoming-Events/2025-OME-NGFF-workshop.html)| |
-| Nov 2-6, 2026 | [2026 OME-Zarr Hackathons](https://biovisioncenter.notion.site/2026-ome-zarr-hackathon)| |
+| Nov 18-22, 2024 | [2024 OME-NGFF Workflows Hackathon](https://biovisioncenter.uzh.ch/en/events/2024/hackaton_november_2024.html)| [2024 Preprint](https://doi.org/10.37044/osf.io/5uhwz_v1)|
+| Nov 6-8, 2023 | [Next generation bioimage analysis workflows hackathon](https://www.biovisioncenter.uzh.ch/en/events/2023/hackathon_23.html)| [2023 image.sc post](https://forum.image.sc/t/outcomes-of-the-next-generation-bioimage-analysis-workflows-hackathon/88733)|
 
+The OME Community Meeting is also a prime event to interact with the NGFF community.
+It is hosted yearly in different location around the world.
+
+| Dates  | Location | Resources |
+| ------ | ------- | -------- |
+| Jun 1-4, 2027 | Zurich, Switzerland | [image.sc post](https://forum.image.sc/t/ome2027-june-1-4-zurich-switzerland/121823) |
+| Apr 28-30, 2026 | Düsseldorf, Germany | [website](https://gerbi-gmb.de/event/ome-2026-community-meeting/) |
 
 
 ```{image} ../images/hackathons/IMG_7670.jpeg
@@ -57,4 +66,5 @@ Dedicated hackathons and workshops have been hosted yearly by the BioVision Cent
 (community:contributors)=
 Thank you to all the amazing contributors who make OME-NGFF possible:
 
-<iframe src="https://german-bioimaging.github.io/ome-zarr-acknowledgments/" width="800" height="1400"></iframe>
+<iframe src="https://german-bioimaging.github.io/ome-zarr-acknowledgments/"
+  style="width:100%; max-width:800px; height:1400px;"></iframe>


### PR DESCRIPTION
Add the hackathon and OME2027 to the Community page and fix behaviour of iframes

Closes #573

I think we can keep the page lean and add other events (besides NGFF Hackathon and OME meeting) to the calendar

- **move calendar up so it is quicker to reach**
- **add hackathon and OME2027, fix iframes**
