### PR TITLE
RFC-4: re-sync the axes schema description with the RFC text

### DIFF
--- a/rfc/4/markdown/Axes.md
+++ b/rfc/4/markdown/Axes.md
@@ -17,6 +17,6 @@ URI: [ngff:Axes](https://w3id.org/ome/ngff/Axes)
 ### Own
 
  * [➞axes](axes__axes.md)  <sub>0..\*</sub>
-     * Description: A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same and the value MUST be unique.
+     * Description: A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each orientation MUST be one of the types defined by this specification, currently only "anatomical", and two axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set { "left-to-right", "right-to-left" } or { "anterior-to-posterior", "posterior-to-anterior" } or the remaining values.
 
      * Range: [String](types/String.md)

--- a/rfc/4/markdown/SpaceAxis.md
+++ b/rfc/4/markdown/SpaceAxis.md
@@ -28,7 +28,8 @@ URI: [ngff:SpaceAxis](https://w3id.org/ome/ngff/SpaceAxis)
 
      * Range: [SpaceUnit](SpaceUnit.md)
  * [➞orientation](spaceAxis__orientation.md)  <sub>0..1</sub>
-     * Description: The direction of an axis of type space.
+     * Description: The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.
+
      * Range: [String](types/String.md)
  * [SpaceAxis➞name](SpaceAxis_name.md)  <sub>1..1</sub>
      * Range: [SpaceAxesNames](SpaceAxesNames.md)

--- a/rfc/4/markdown/axes__axes.md
+++ b/rfc/4/markdown/axes__axes.md
@@ -4,7 +4,7 @@ orphan: true
 
 # Slot: axes
 
-A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same and the value MUST be unique.
+A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each orientation MUST be one of the types defined by this specification, currently only "anatomical", and two axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set { "left-to-right", "right-to-left" } or { "anterior-to-posterior", "posterior-to-anterior" } or the remaining values.
 
 URI: [ngff:axes__axes](https://w3id.org/ome/ngff/axes__axes)
 

--- a/rfc/4/markdown/spaceAxis__orientation.md
+++ b/rfc/4/markdown/spaceAxis__orientation.md
@@ -4,7 +4,7 @@ orphan: true
 
 # Slot: orientation
 
-The direction of an axis of type space.
+The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.
 
 URI: [ngff:spaceAxis__orientation](https://w3id.org/ome/ngff/spaceAxis__orientation)
 

--- a/rfc/4/orientation.py
+++ b/rfc/4/orientation.py
@@ -305,7 +305,7 @@ class AnatomicalOrientationValues(str, Enum):
 class Axes(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/ome/ngff'})
 
-    axes: Optional[list[Union[ChannelAxis, SpaceAxis, TimeAxis]]] = Field(default=None, description="""A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same and the value MUST be unique.
+    axes: Optional[list[Union[ChannelAxis, SpaceAxis, TimeAxis]]] = Field(default=None, description="""A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each orientation MUST be one of the types defined by this specification, currently only \"anatomical\", and two axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set { \"left-to-right\", \"right-to-left\" } or { \"anterior-to-posterior\", \"posterior-to-anterior\" } or the remaining values.
 """, json_schema_extra = { "linkml_meta": {'alias': 'axes',
          'any_of': [{'range': 'SpaceAxis'},
                     {'range': 'TimeAxis'},
@@ -353,7 +353,8 @@ class SpaceAxis(Axis):
 
     unit: SpaceUnit = Field(default=..., description="""Physical unit for spatial measurement along the axis, selected from a standardized list of distance units (e.g., micrometer, nanometer).
 """, json_schema_extra = { "linkml_meta": {'alias': 'unit', 'domain_of': ['SpaceAxis', 'TimeAxis']} })
-    orientation: Optional[AnatomicalOrientation] = Field(default=None, description="""The direction of an axis of type space.""", json_schema_extra = { "linkml_meta": {'alias': 'orientation',
+    orientation: Optional[AnatomicalOrientation] = Field(default=None, description="""The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.
+""", json_schema_extra = { "linkml_meta": {'alias': 'orientation',
          'any_of': [{'range': 'AnatomicalOrientation'}],
          'domain_of': ['SpaceAxis']} })
     name: SpaceAxesNames = Field(default=..., json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['Axis']} })

--- a/rfc/4/orientation.schema.json
+++ b/rfc/4/orientation.schema.json
@@ -54,7 +54,7 @@
             "description": "",
             "properties": {
                 "axes": {
-                    "description": "A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same and the value MUST be unique.\n",
+                    "description": "A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each orientation MUST be one of the types defined by this specification, currently only \"anatomical\", and two axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set { \"left-to-right\", \"right-to-left\" } or { \"anterior-to-posterior\", \"posterior-to-anterior\" } or the remaining values.\n",
                     "items": {
                         "anyOf": [
                             {
@@ -146,7 +146,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "The direction of an axis of type space.",
+                    "description": "The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.\n",
                     "type": "string"
                 },
                 "type": {

--- a/rfc/4/orientation.ts
+++ b/rfc/4/orientation.ts
@@ -150,7 +150,7 @@ export enum AnatomicalOrientationValues {
 
 
 export interface Axes {
-    /** A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same and the value MUST be unique.
+    /** A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each orientation MUST be one of the types defined by this specification, currently only "anatomical", and two axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set { "left-to-right", "right-to-left" } or { "anterior-to-posterior", "posterior-to-anterior" } or the remaining values.
  */
     axes?: string[],
 }
@@ -173,7 +173,8 @@ export interface SpaceAxis extends Axis {
     /** Physical unit for spatial measurement along the axis, selected from a standardized list of distance units (e.g., micrometer, nanometer).
  */
     unit: string,
-    /** The direction of an axis of type space. */
+    /** The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.
+ */
     orientation?: string,
 }
 

--- a/rfc/4/orientation.yml
+++ b/rfc/4/orientation.yml
@@ -32,9 +32,12 @@ classes:
       axes:
         description: >
           A list of axes. Although serialized as list, it MUST be dealt with as being a set as in the name of each axis
-          MUST be unique. Furthermore, if the attribute orientation is defined for one axis of type space, it
-          MUST be defined for all the axes of type space. In this case, the type of each orientation MUST be the same
-          and the value MUST be unique.
+          MUST be unique. The orientation attribute is OPTIONAL: it MAY be defined on any subset of the axes of type
+          space, and it MUST NOT be defined on axes of any other type. Where it is defined, the type of each
+          orientation MUST be one of the types defined by this specification, currently only "anatomical", and two
+          axes MUST NOT describe the same anatomical axis: a set of axes MUST only have one of the set
+          { "left-to-right", "right-to-left" } or { "anterior-to-posterior", "posterior-to-anterior" } or the
+          remaining values.
         multivalued: true
         any_of:
           - range: SpaceAxis
@@ -84,7 +87,10 @@ classes:
         range: SpaceUnit
         required: true
       orientation:
-        description: The direction of an axis of type space.
+        description: >
+          The direction of an axis of type space. This attribute is OPTIONAL. An axis with no orientation and an axis
+          whose orientation is null are equivalent: in both cases the orientation of that axis is undefined, and
+          neither implies a default value. Writers SHOULD omit the attribute rather than serialize a null value.
         any_of:
           - range: AnatomicalOrientation
         required: false


### PR DESCRIPTION
The `axes` slot description in `rfc/4/orientation.yml` states two rules that the
RFC text does not:

> Furthermore, if the attribute orientation is defined for one axis of type
> space, it MUST be defined for all the axes of type space. In this case, the
> type of each orientation MUST be the same and the value MUST be unique.

Against the current `rfc/4/index.md`:

* `orientation` is OPTIONAL and no completeness requirement is stated, so an
  image may orient only some of its spatial axes. A limb scan, for example, can
  give a proximal/distal direction for one axis and leave the medio-lateral
  axis undefined.
* A single `type` is defined, `"anatomical"`. Requiring the declared types to
  agree with each other accepts metadata that uses a type the RFC does not
  define.
* The constraint on values is the mutual exclusion rule: "A set of NGFF `axes`
  MUST only have one of the set { left-to-right, right-to-left } or
  { anterior-to-posterior, posterior-to-anterior } or the remaining values."

The model structure already matches the RFC, since `orientation` is optional and
nullable. Only the description was out of date, and it propagates into
`orientation.schema.json`, `orientation.py`, `orientation.ts` and `markdown/`,
where implementers read it as normative.

The `orientation` slot description now also carries the equivalence added in
254c1b2: an absent orientation and a `null` orientation mean the same thing, and
writers should omit the field rather than serialize `null`.

Generated with `pixi run gen-all` in `rfc/4`, then the `orphan: true` front
matter was restored on the markdown pages, which `gen-markdown` does not emit.
Running the generators on an unmodified tree produces no other diff. The JSON
Schema changes only in `description` strings, so no document changes validity.

Found while aligning RFC 4 validation in ngff-zarr
(fideus-labs/ngff-zarr#613), where the removed sentences had been implemented
as constraints.
