### PR TITLE
Contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We welcome contributions from anyone! Create Issues and PRs on this repo for con
 
 Content can be created using Markdown, HTML, and [MyST](https://myst-parser.readthedocs.io/en/latest/) syntax.
 
-See also [CONTRIBUTING.md](./contributing/index.md)
+For more information on authorship, see [CONTRIBUTING.md](./contributing/index.md)
 
 # Specifications
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Contributing
 
-We welcome contributions from anyone! Create Issues and PRs on this repo for content on https://ngff.openmicroscopy.org.
+We welcome contributions from anyone! Create Issues and PRs on this repo for content on https://ngff.openmicroscopy.org. Get started with the instructions for [contributing to this website](./contributing/website/index.md).
 
 Content can be created using Markdown, HTML, and [MyST](https://myst-parser.readthedocs.io/en/latest/) syntax.
 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -36,7 +36,7 @@ which can be used for citation of the specification in publications and other wo
 
 To ensure the visibility of all contributions to the broader ecosystem that are not directly related to specification development,
 a list of contributors is maintained in the [ome-zarr-acknowledgements](https://github.com/german-BioImaging/ome-zarr-acknowledgments/) repository,
-which is displayed [here](community:contributors).
+which is displayed on the [community page](community:contributors).
 Any contribution to the NGFF ecosystem can be acknowledged in this repository, including but not limited to
 - Contribution to spec development
 - Maintenance of software implementations of ome-zarr

--- a/contributing/website/index.md
+++ b/contributing/website/index.md
@@ -32,28 +32,15 @@ pip install specifications/dev
 ```
 
 Then, you can build the pages locally with:
-
 ```bash
 make html
 ```
-
-or 
-
-```bash
-python conf.py
-```
-
 You can then find the rendered pages under `_build/html/index.html`.
 
-## Previewing the pages locally
-```bash
-pip install sphinx-autobuild
-```
-
+Alternatively, to build and preview the pages locally:
 ```bash
 sphinx-autobuild . _build/html
 ```
-
 The website will then be served at http://127.0.0.1:8000.
 
 ## PR previews

--- a/contributing/website/index.md
+++ b/contributing/website/index.md
@@ -6,6 +6,15 @@ Contributions to these pages are welcome as issues or PRs.
 To do so, create a fork of the ``ome/ngff`` repository, make your changes,
 and submit a pull request (PR) against the `main` branch.
 
+## Setting up the repository
+Create a fork of the ``ome/ngff`` repository.
+
+When cloning your fork locally, you will need to pull the submodules in `specifications/`:
+```bash
+git submodule init
+git submodule update
+```
+
 ## Configuration
 Edit [conf.py](https://github.com/ome/ngff/blob/main/conf.py) with options from the [PyData Theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/). The [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/index.html) user guide may also have more up to date instructions for configuration properties.
 
@@ -36,7 +45,18 @@ python conf.py
 
 You can then find the rendered pages under `_build/html/index.html`.
 
-## Previews
+## Previewing the pages locally
+```bash
+pip install sphinx-autobuild
+```
+
+```bash
+sphinx-autobuild . _build/html
+```
+
+The website will then be served at http://127.0.0.1:8000.
+
+## PR previews
 Each PR receives a unique preview URL of the format `https://ngff--<PR#>.org.readthedocs.build/` where `<PR#>` is the PR number. This link is also posted to each PR by the Github actions bot in an "Automated Review URLs" comment as the "Readthedocs" link.
 
 Please check that your changes render correctly at this URL. New commits will automatically be live at the PR url after a few minutes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ testresources
 sphinx-reredirects
 sphinxcontrib-bibtex
 sphinx-design
+sphinx-autobuild


### PR DESCRIPTION
Cleaning up the contributing experience a little:
- Added link from readme to page that actually has instructions for contributing to this repo
- Instructions for submodules
- Instructions for sphinx-autobuild

Lingering question: there's the foundations of an all-contributors table in the readme, but it's currently blank. We could either build that or just delete it and the .all-contributorsrc, perhaps linking to https://github.com/German-BioImaging/ome-zarr-acknowledgments instead. Thoughts?

@lubianat 