### PR TITLE
Update RFC-5 status

### DIFF
--- a/rfc/5/index.md
+++ b/rfc/5/index.md
@@ -14,7 +14,7 @@ Add named coordinate systems and expand and clarify coordinate transformations. 
 
 ## Status
 
-This RFC is currently in RFC state `S4` (Update implementations).
+This RFC is currently in RFC state `S3` (Update implementations).
 
 | **Role** | Name | GitHub Handle | Institution | Date | Status |
 |----------|------|---------------|-------------|------|--------|

--- a/rfc/listing.csv
+++ b/rfc/listing.csv
@@ -4,7 +4,7 @@ RFC,Description,Date,Status,OME-Zarr Version
 [2](2/index.md),Zarr V3 Support,2024,Adopted,0.5
 [3](3/index.md),Remove axis restrictions,2024,Under review,
 [4](4/index.md),Axis Anatomical Orientation,2024,Under review,
-[5](5/index.md),Coordinate systems and transformations,2024,Under review,
+[5](5/index.md),Coordinate systems and transformations,2024,Implementation,
 [6](6/index.md),Flattening the multiscales array,2025,Superseded,
 [7](7/index.md),Channel provenance,TBD,TBD,
 [8](8/index.md),Collections,2026,Under review,


### PR DESCRIPTION
This PR updates the status of RFC-5 in the status table to "Implementation". An alternative would be "S3 update implementations), which is closer to the language in the RFC-1 flow chart, but I think "Implementation" more closely matches the language in the rest of the table.

Also, I changed the status in the RFC page to "S3" as I think "S4" is for when the first two implementations are complete and the RFC is adopted (see the [RFC-1 flowchart](https://ngff.openmicroscopy.org/rfc/1/index.html#implementation)).

cc @jo-mueller 